### PR TITLE
feat: User 엔티티 도메인 모델 및 매핑 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,19 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT 처리용 라이브러리 (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // H2 임베디드 DB (테스트용)
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/eventitta/config/AuditorAwareImpl.java
+++ b/src/main/java/com/eventitta/config/AuditorAwareImpl.java
@@ -1,0 +1,19 @@
+package com.eventitta.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getPrincipal().equals("anonymousUser")) {
+            return Optional.empty();
+        }
+        return Optional.of(auth.getName());
+    }
+}

--- a/src/main/java/com/eventitta/config/BaseEntity.java
+++ b/src/main/java/com/eventitta/config/BaseEntity.java
@@ -1,0 +1,35 @@
+package com.eventitta.config;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", length = 100, updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", length = 100)
+    private String updatedBy;
+}

--- a/src/main/java/com/eventitta/config/JpaAuditingConfig.java
+++ b/src/main/java/com/eventitta/config/JpaAuditingConfig.java
@@ -1,0 +1,16 @@
+package com.eventitta.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/eventitta/user/domain/Provider.java
+++ b/src/main/java/com/eventitta/user/domain/Provider.java
@@ -1,0 +1,7 @@
+package com.eventitta.user.domain;
+
+public enum Provider {
+    LOCAL,
+    KAKAO,
+    APPLE
+}

--- a/src/main/java/com/eventitta/user/domain/Role.java
+++ b/src/main/java/com/eventitta/user/domain/Role.java
@@ -1,0 +1,6 @@
+package com.eventitta.user.domain;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -1,0 +1,74 @@
+package com.eventitta.user.domain;
+
+import com.eventitta.config.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @Email
+    @NotBlank
+    @Size(max = 255)
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @NotBlank @Size(min = 8, max = 255)
+    private String password;
+
+    @NotBlank @Size(max = 100)
+    private String nickname;
+
+    @Column(name = "profile_picture_url", length = 512)
+    private String profilePictureUrl;
+
+    @Column(name = "self_intro", columnDefinition = "TEXT")
+    private String selfIntro;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private List<String> interests;
+
+    @Size(max = 255)
+    private String address;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal longitude;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private Provider provider;
+
+    @Column(name = "provider_id", length = 100)
+    private String providerId;
+}

--- a/src/main/java/com/eventitta/user/repository/UserRepository.java
+++ b/src/main/java/com/eventitta/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.eventitta.user.repository;
+
+import com.eventitta.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,30 @@
+# src/test/resources/application-test.yml
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    url: jdbc:h2:mem:eventitta-test;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+logging:
+  level:
+    root: DEBUG
+    org.hibernate.SQL: DEBUG
+

--- a/src/test/java/com/eventitta/config/AuditorAwareImplTest.java
+++ b/src/test/java/com/eventitta/config/AuditorAwareImplTest.java
@@ -1,0 +1,50 @@
+package com.eventitta.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("현재 사용자 조회 기능")
+class AuditorAwareImplTest {
+    private final AuditorAwareImpl auditor = new AuditorAwareImpl();
+
+    @AfterEach
+    void clear() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증 정보가 주어지지 않으면 사용자 식별 결과가 없다")
+    void noAuth_returnsEmpty() {
+        assertThat(auditor.getCurrentAuditor()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("익명 사용자(anonymousUser)로 인증된 경우 사용자 식별 결과가 없다")
+    void anonymousUser_returnsEmpty() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("anonymousUser",null)
+        );
+        assertThat(auditor.getCurrentAuditor()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 SecurityContext에 설정되면 사용자 이름을 반환한다")
+    void authenticated_returnsName() {
+        List<GrantedAuthority> auths = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("alice", null, auths);
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        assertThat(auditor.getCurrentAuditor()).hasValue("alice");
+    }
+}


### PR DESCRIPTION
## 🔍 해결하려는 문제가 무엇인가요?
- User 도메인 모델이 아직 정의되지 않아, 회원 데이터 저장·조회가 불가능합니다.
- BaseEntity 상속을 통한 공통 생성·수정 이력 관리도 미구현 상태입니다.

## 🎯 기능 기획 및 배경
- 회원 정보를 저장·조회할 JPA 도메인(엔티티) 계층이 필요합니다.  
- MySQL DDL 스펙에 맞춰 User 엔티티 필드를 매핑하고,  
  공통 생성/수정 이력(audit)을 자동 관리해야 합니다.

## 🛠️ 어떻게 해결했나요?
- **Auditing**: `BaseEntity` + `JpaAuditingConfig` + `AuditorAwareImpl` 설정  
- **User 엔티티 매핑**  
  - `id` → `INT UNSIGNED` (`@Column(columnDefinition="INT UNSIGNED")`)  
  - `email`, `password`, `nickname`, `profilePictureUrl`, `selfIntro` 등 기본 필드  
  - `interests` → JSON 컬럼 (`@JdbcTypeCode(SqlTypes.JSON)`)  
  - `address`, `latitude(precision=9, scale=6)`, `longitude(9,6)`  
  - `Role`, `Provider` → `EnumType.STRING`  
  - `providerId` 필드 추가 (소셜 로그인용)  
- **단위 테스트**: `AuditorAwareImplTest`로 audit 사용자 식별 로직 검증  

## ✨ 주요 변경사항
- `User.java`, `Role.java`, `Provider.java` (도메인 엔티티/enum)  
- `BaseEntity.java`, `JpaAuditingConfig.java`, `AuditorAwareImpl.java` (Auditing 설정)  
- `AuditorAwareImplTest.java` (JUnit5 단위 테스트)

## ✅ 검증 시나리오
- [ ] User 엔티티 저장 시 DDL 스펙과 일치하는 컬럼 매핑 확인  
- [ ] BaseEntity 생성/수정 이력 필드 자동 채워짐 확인  
- [ ] 인증 정보 없을 때 audit ‘createdBy’가 비어 있음  
- [ ] 인증된 사용자 설정 시 ‘createdBy’에 사용자명 채워짐  

## ⚙️ 머지 전 체크
- [ ] 코드 스타일/포맷팅 확인  
- [ ] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
- ERD 다이어그램: https://www.erdcloud.com/d/5m5fetQv9mgow4un7

## 📚 참고 링크
- 공통 Audit 가이드: [Spring Data JPA Auditing  ](https://docs.spring.io/spring-data/jpa/reference/auditing.html)