### PR TITLE
feat: 유저 회원가입

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ max_line_length = 120
 indent_style = space
 indent_size = 4
 tab_width = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+tab_width = 2

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,13 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // JWT 처리용 라이브러리 (jjwt)
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.eventitta.auth.controller;
+
+import com.eventitta.auth.dto.request.SignUpRequest;
+import com.eventitta.auth.dto.response.SignUpResponse;
+import com.eventitta.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostMapping("/signup")
+    public SignUpResponse signUp(@Valid @RequestBody SignUpRequest req) {
+        var user = authService.signUp(req.toEntity(passwordEncoder));
+        return SignUpResponse.of(user);
+    }
+}
+

--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.eventitta.auth.controller;
 import com.eventitta.auth.dto.request.SignUpRequest;
 import com.eventitta.auth.dto.response.SignUpResponse;
 import com.eventitta.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "인증 API", description = "회원가입, 로그인 등의 인증 관련 API")
 public class AuthController {
     private final AuthService authService;
     private final PasswordEncoder passwordEncoder;
 
+    @Operation(summary = "회원가입", description = "회원 정보를 받아 회원가입을 수행합니다.")
     @PostMapping("/signup")
     public SignUpResponse signUp(@Valid @RequestBody SignUpRequest req) {
         var user = authService.signUp(req.toEntity(passwordEncoder));

--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "인증 API", description = "회원가입, 로그인 등의 인증 관련 API")
 public class AuthController {
     private final AuthService authService;
-    private final PasswordEncoder passwordEncoder;
 
     @Operation(summary = "회원가입", description = "회원 정보를 받아 회원가입을 수행합니다.")
     @PostMapping("/signup")
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest req) {
-        var user = authService.signUp(req.toEntity(passwordEncoder));
+        var user = authService.signUp(req);
         return ResponseEntity.ok(SignUpResponse.of(user));
     }
 }

--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,9 +24,9 @@ public class AuthController {
 
     @Operation(summary = "회원가입", description = "회원 정보를 받아 회원가입을 수행합니다.")
     @PostMapping("/signup")
-    public SignUpResponse signUp(@Valid @RequestBody SignUpRequest req) {
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest req) {
         var user = authService.signUp(req.toEntity(passwordEncoder));
-        return SignUpResponse.of(user);
+        return ResponseEntity.ok(SignUpResponse.of(user));
     }
 }
 

--- a/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
@@ -8,7 +8,6 @@ import com.eventitta.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Schema(description = "회원가입")
@@ -23,7 +22,6 @@ public record SignUpRequest(
     String password,
     @Schema(description = "닉네임", example = "johndoe", minLength = 2, maxLength = 20, pattern = RegexPattern.NICKNAME)
     @NotBlank(message = ValidationMessage.NICKNAME)
-    @Size(min = 2, max = 20, message = ValidationMessage.NICKNAME)
     @Pattern(regexp = RegexPattern.NICKNAME, message = ValidationMessage.NICKNAME)
     String nickname
 

--- a/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
@@ -19,7 +19,6 @@ public record SignUpRequest(
     String email,
     @Schema(description = "비밀번호", example = "P@ssw0rd!", pattern = RegexPattern.PASSWORD)
     @NotBlank(message = ValidationMessage.PASSWORD)
-    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
     @Pattern(regexp = RegexPattern.PASSWORD, message = ValidationMessage.PASSWORD)
     String password,
     @Schema(description = "닉네임", example = "johndoe", minLength = 2, maxLength = 20, pattern = RegexPattern.NICKNAME)

--- a/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/eventitta/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,41 @@
+package com.eventitta.auth.dto.request;
+
+import com.eventitta.common.constants.RegexPattern;
+import com.eventitta.common.constants.ValidationMessage;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Schema(description = "회원가입")
+public record SignUpRequest(
+    @Schema(description = "이메일", example = "user@example.com", pattern = RegexPattern.EMAIL)
+    @NotBlank(message = ValidationMessage.EMAIL)
+    @Pattern(regexp = RegexPattern.EMAIL, message = ValidationMessage.EMAIL)
+    String email,
+    @Schema(description = "비밀번호", example = "P@ssw0rd!", pattern = RegexPattern.PASSWORD)
+    @NotBlank(message = ValidationMessage.PASSWORD)
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    @Pattern(regexp = RegexPattern.PASSWORD, message = ValidationMessage.PASSWORD)
+    String password,
+    @Schema(description = "닉네임", example = "johndoe", minLength = 2, maxLength = 20, pattern = RegexPattern.NICKNAME)
+    @NotBlank(message = ValidationMessage.NICKNAME)
+    @Size(min = 2, max = 20, message = ValidationMessage.NICKNAME)
+    @Pattern(regexp = RegexPattern.NICKNAME, message = ValidationMessage.NICKNAME)
+    String nickname
+
+) {
+    public User toEntity(PasswordEncoder encoder) {
+        return User.builder()
+            .email(email)
+            .password(encoder.encode(password))
+            .nickname(nickname)
+            .role(Role.USER)
+            .provider(Provider.LOCAL)
+            .build();
+    }
+}

--- a/src/main/java/com/eventitta/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/com/eventitta/auth/dto/response/SignUpResponse.java
@@ -1,0 +1,19 @@
+package com.eventitta.auth.dto.response;
+
+import com.eventitta.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 응답")
+public record SignUpResponse(
+    @Schema(description = "이메일", example = "user@example.com")
+    String email,
+    @Schema(description = "닉네임", example = "johndoe")
+    String nickname
+) {
+    public static SignUpResponse of(User user) {
+        return new SignUpResponse(
+            user.getEmail(),
+            user.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/eventitta/auth/exception/SignUpErrorCode.java
+++ b/src/main/java/com/eventitta/auth/exception/SignUpErrorCode.java
@@ -1,0 +1,36 @@
+package com.eventitta.auth.exception;
+
+import com.eventitta.common.exception.CustomException;
+import com.eventitta.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SignUpErrorCode implements ErrorCode {
+    CONFLICTED_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),
+    CONFLICTED_NICKNAME("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    DEFAULT("회원가입 도중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public CustomException defaultException() {
+        return new CustomException(this);
+    }
+
+    @Override
+    public CustomException defaultException(Throwable cause) {
+        return new CustomException(this, cause);
+    }
+}

--- a/src/main/java/com/eventitta/auth/service/AuthService.java
+++ b/src/main/java/com/eventitta/auth/service/AuthService.java
@@ -1,10 +1,12 @@
 package com.eventitta.auth.service;
 
+import com.eventitta.auth.dto.request.SignUpRequest;
 import com.eventitta.auth.exception.SignUpErrorCode;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,14 +14,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public User signUp(User user) {
-        if (userRepository.existsByEmail(user.getEmail())) {
+    public User signUp(SignUpRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
             throw SignUpErrorCode.CONFLICTED_EMAIL.defaultException();
         }
-        if (userRepository.existsByNickname(user.getNickname())) {
+        if (userRepository.existsByNickname(request.nickname())) {
             throw SignUpErrorCode.CONFLICTED_NICKNAME.defaultException();
         }
-        return userRepository.save(user);
+        return userRepository.save(request.toEntity(passwordEncoder));
     }
 }

--- a/src/main/java/com/eventitta/auth/service/AuthService.java
+++ b/src/main/java/com/eventitta/auth/service/AuthService.java
@@ -1,0 +1,25 @@
+package com.eventitta.auth.service;
+
+import com.eventitta.auth.exception.SignUpErrorCode;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+
+    public User signUp(User user) {
+        if (userRepository.existsByEmail(user.getEmail())) {
+            throw SignUpErrorCode.CONFLICTED_EMAIL.defaultException();
+        }
+        if (userRepository.existsByNickname(user.getNickname())) {
+            throw SignUpErrorCode.CONFLICTED_NICKNAME.defaultException();
+        }
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/eventitta/common/config/AuditorAwareImpl.java
+++ b/src/main/java/com/eventitta/common/config/AuditorAwareImpl.java
@@ -1,4 +1,4 @@
-package com.eventitta.config;
+package com.eventitta.common.config;
 
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/eventitta/common/config/BaseEntity.java
+++ b/src/main/java/com/eventitta/common/config/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.eventitta.config;
+package com.eventitta.common.config;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/eventitta/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/eventitta/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package com.eventitta.config;
+package com.eventitta.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.eventitta.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Eventitta API 명세")
+                .version("v1.0.0")
+                .description("Eventitta 프로젝트의 REST API 명세서입니다.")
+            );
+    }
+}

--- a/src/main/java/com/eventitta/common/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/common/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.eventitta.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth ->
+                auth.requestMatchers(
+                        "/api/v1/auth/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html")
+                    .permitAll()
+                    .anyRequest().authenticated()
+            )
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+}

--- a/src/main/java/com/eventitta/common/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/common/config/SecurityConfig.java
@@ -12,6 +12,10 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
@@ -31,6 +35,7 @@ public class SecurityConfig {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(auth ->
                 auth.requestMatchers(
                         "/api/v1/auth/**",
@@ -42,5 +47,16 @@ public class SecurityConfig {
             )
             .httpBasic(Customizer.withDefaults());
         return http.build();
+    }
+
+    private CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration configuration = new CorsConfiguration();
+            configuration.setAllowedHeaders(Collections.singletonList("*"));
+            configuration.setAllowedMethods(Collections.singletonList("*"));
+            configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
+            configuration.setAllowCredentials(true);
+            return configuration;
+        };
     }
 }

--- a/src/main/java/com/eventitta/common/constants/RegexPattern.java
+++ b/src/main/java/com/eventitta/common/constants/RegexPattern.java
@@ -1,0 +1,11 @@
+package com.eventitta.common.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RegexPattern {
+    public static final String EMAIL = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$";
+    public static final String PASSWORD = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+{};:,<.>]).{8,20}$";
+    public static final String NICKNAME = "^[가-힣a-zA-Z0-9]{2,20}$";
+}

--- a/src/main/java/com/eventitta/common/constants/ValidationMessage.java
+++ b/src/main/java/com/eventitta/common/constants/ValidationMessage.java
@@ -1,0 +1,11 @@
+package com.eventitta.common.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ValidationMessage {
+    public static final String EMAIL = "올바른 이메일 형식이어야 합니다.";
+    public static final String PASSWORD = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.";
+    public static final String NICKNAME = "닉네임은 2자 이상 20자 이하로 입력해주세요.";
+}

--- a/src/main/java/com/eventitta/common/constants/ValidationMessage.java
+++ b/src/main/java/com/eventitta/common/constants/ValidationMessage.java
@@ -6,6 +6,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ValidationMessage {
     public static final String EMAIL = "올바른 이메일 형식이어야 합니다.";
-    public static final String PASSWORD = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.";
+    public static final String PASSWORD = "비밀번호는 8~20자이며, 영문, 숫자, 특수문자를 모두 포함해야 합니다.";
     public static final String NICKNAME = "닉네임은 2자 이상 20자 이하로 입력해주세요.";
 }

--- a/src/main/java/com/eventitta/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/eventitta/common/exception/CommonErrorCode.java
@@ -1,0 +1,55 @@
+package com.eventitta.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_INPUT("입력값이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_JSON("요청 본문이 JSON 형식이 아닙니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CONSTRAINT("검증 제약조건을 위반했습니다.", HttpStatus.BAD_REQUEST),
+    MISSING_PARAMETER("필수 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST),
+    TYPE_MISMATCH("파라미터 타입이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+
+    FORBIDDEN("해당 리소스에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    METHOD_NOT_ALLOWED("지원하지 않는 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+
+    DUPLICATE_RESOURCE("이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
+    STATE_CONFLICT("현재 상태에서는 해당 요청을 수행할 수 없습니다.", HttpStatus.CONFLICT),
+
+    INTERNAL_ERROR("예상치 못한 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SERVICE_UNAVAILABLE("일시적인 오류로 요청을 처리할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+
+    private final String message;
+    private final HttpStatus status;
+
+    CommonErrorCode(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public RuntimeException defaultException() {
+        return new CustomException(this);
+    }
+
+    @Override
+    public RuntimeException defaultException(Throwable cause) {
+        return new CustomException(this, cause);
+    }
+}

--- a/src/main/java/com/eventitta/common/exception/CustomException.java
+++ b/src/main/java/com/eventitta/common/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.eventitta.common.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.defaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.defaultMessage(), cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/eventitta/common/exception/ErrorCode.java
+++ b/src/main/java/com/eventitta/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.eventitta.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+
+    String defaultMessage();
+
+    HttpStatus defaultHttpStatus();
+
+    RuntimeException defaultException();
+
+    RuntimeException defaultException(Throwable cause);
+}

--- a/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.eventitta.common.exception;
+
+import com.eventitta.common.response.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final HttpServletRequest request;
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiErrorResponse> handleCustom(CustomException ex) {
+        return toResponse(ex.getErrorCode());
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(NoResourceFoundException ex) {
+        return toResponse(CommonErrorCode.RESOURCE_NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+            .findFirst()
+            .map(err -> err.getField() + ": " + err.getDefaultMessage())
+            .orElse(CommonErrorCode.INVALID_INPUT.defaultMessage());
+
+        return toResponse(CommonErrorCode.INVALID_INPUT, message);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiErrorResponse> handleConstraint(ConstraintViolationException ex) {
+        return toResponse(CommonErrorCode.INVALID_CONSTRAINT, ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleBadRequest(HttpMessageNotReadableException ex) {
+        return toResponse(CommonErrorCode.INVALID_JSON);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiErrorResponse> handleMissingParam(MissingServletRequestParameterException ex) {
+        String message = ex.getParameterName() + " 파라미터가 필요합니다.";
+        return toResponse(CommonErrorCode.MISSING_PARAMETER, message);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex) {
+        return toResponse(CommonErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleUnknown(Exception ex) {
+        return toResponse(CommonErrorCode.INTERNAL_ERROR);
+    }
+
+    private ResponseEntity<ApiErrorResponse> toResponse(ErrorCode code) {
+        return ResponseEntity.status(code.defaultHttpStatus())
+            .body(ApiErrorResponse.of(code.name(), code.defaultMessage(), code.defaultHttpStatus().value(), request.getRequestURI()));
+    }
+
+    private ResponseEntity<ApiErrorResponse> toResponse(ErrorCode code, String overrideMessage) {
+        return ResponseEntity.status(code.defaultHttpStatus())
+            .body(ApiErrorResponse.of(code.name(), overrideMessage, code.defaultHttpStatus().value(), request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/eventitta/common/response/ApiErrorResponse.java
+++ b/src/main/java/com/eventitta/common/response/ApiErrorResponse.java
@@ -1,0 +1,31 @@
+package com.eventitta.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "API 에러 응답")
+public record ApiErrorResponse(
+    @Schema(description = "에러 코드", example = "INVALID_INPUT")
+    String error,
+
+    @Schema(description = "에러 메시지", example = "email: 올바른 이메일 형식이 아닙니다.")
+    String message,
+
+    @Schema(description = "HTTP 상태 코드", example = "400")
+    int status,
+
+    @Schema(description = "요청 경로", example = "/api/v1/users")
+    String path,
+
+    @Schema(description = "에러 발생 시각 (ISO-8601)", example = "2025-05-07T13:30:20Z")
+    String timestamp
+) {
+    public static ApiErrorResponse of(String error, String message, int status, String path) {
+        return new ApiErrorResponse(
+            error,
+            message,
+            status,
+            path,
+            java.time.Instant.now().toString()
+        );
+    }
+}

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -1,6 +1,6 @@
 package com.eventitta.user.domain;
 
-import com.eventitta.config.BaseEntity;
+import com.eventitta.common.config.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -36,10 +36,12 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @NotBlank @Size(min = 8, max = 255)
+    @NotBlank
+    @Size(min = 8, max = 255)
     private String password;
 
-    @NotBlank @Size(max = 100)
+    @NotBlank
+    @Size(max = 100)
     private String nickname;
 
     @Column(name = "profile_picture_url", length = 512)

--- a/src/main/java/com/eventitta/user/repository/UserRepository.java
+++ b/src/main/java/com/eventitta/user/repository/UserRepository.java
@@ -4,4 +4,7 @@ import com.eventitta.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -11,12 +11,10 @@ spring:
     password:
 
   jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create-drop
     show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
 
   h2:
     console:

--- a/src/test/java/com/eventitta/ControllerTestSupport.java
+++ b/src/test/java/com/eventitta/ControllerTestSupport.java
@@ -1,0 +1,24 @@
+package com.eventitta;
+
+import com.eventitta.auth.controller.AuthController;
+import com.eventitta.auth.service.AuthService;
+import com.eventitta.common.config.SecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+    AuthController.class,
+})
+@Import(SecurityConfig.class)
+public abstract class ControllerTestSupport {
+    @Autowired
+    protected MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @MockitoBean
+    protected AuthService authService;
+}

--- a/src/test/java/com/eventitta/IntegrationTestSupport.java
+++ b/src/test/java/com/eventitta/IntegrationTestSupport.java
@@ -1,0 +1,9 @@
+package com.eventitta;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+}

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -1,0 +1,109 @@
+package com.eventitta.auth.controller;
+
+import com.eventitta.ControllerTestSupport;
+import com.eventitta.auth.dto.request.SignUpRequest;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+
+import static com.eventitta.common.constants.ValidationMessage.*;
+import static com.eventitta.common.exception.CommonErrorCode.INVALID_INPUT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("회원 인증/인가 슬라이스 테스트")
+class AuthControllerTest extends ControllerTestSupport {
+
+    @Test
+    @DisplayName("회원이 유효한 이메일, 비밀번호, 닉네임으로 회원가입하면 사용자 정보가 응답된다.")
+    void 회원가입_성공시_사용자_정보가_응답된다() throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("user@example.com", "P@ssw0rd!", "johndoe");
+
+        User mockUser = User.builder()
+            .id(1L)
+            .email("user@example.com")
+            .password("encoded")
+            .nickname("johndoe")
+            .role(Role.USER)
+            .provider(Provider.LOCAL)
+            .build();
+
+        given(authService.signUp(any())).willReturn(mockUser);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.email").value("user@example.com"))
+            .andExpect(jsonPath("$.nickname").value("johndoe"));
+    }
+
+    @Test
+    @DisplayName("회원이 잘못된 형식의 이메일로 회원가입하면 이메일 형식 오류 메시지가 응답된다.")
+    void 이메일_형식이_유효하지_않으면_에러_메시지를_응답한다() throws Exception {
+        SignUpRequest request = new SignUpRequest("invalid-email", "P@ssw0rd!", "johndoe");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("email: " + EMAIL))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @DisplayName("회원이 8자 미만 비밀번호로 회원가입하면 비밀번호 정책 위반 메시지가 응답된다.")
+    void 비밀번호_형식이_유효하지_않으면_에러_메시지를_응답한다() throws Exception {
+        SignUpRequest request = new SignUpRequest("user@example.com", "1234", "johndoe");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("password: " + PASSWORD))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Password1",    // 특수문자 없음
+        "Password!",    // 숫자 없음
+        "1234!@#$"      // 영문자 없음
+    })
+    @DisplayName("비밀번호가 영문자, 숫자, 특수문자를 모두 포함하지 않으면 비밀번호 정책 위반 메시지가 응답된다.")
+    void 비밀번호가_형식에_맞지_않으면_에러_메시지를_응답한다(String invalidPassword) throws Exception {
+        // given
+        SignUpRequest request = new SignUpRequest("user@example.com", invalidPassword, "johndoe");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("password: " + PASSWORD))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @DisplayName("회원이 허용되지 않은 형식의 닉네임으로 회원가입하면 닉네임 정책 위반 메시지가 응답된다.")
+    void 닉네임_형식이_유효하지_않으면_에러_메시지를_응답한다() throws Exception {
+        SignUpRequest request = new SignUpRequest("user@example.com", "P@ssw0rd!", "!@#");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("nickname: " + NICKNAME))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+}

--- a/src/test/java/com/eventitta/auth/controller/AuthIntegrationTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthIntegrationTest.java
@@ -1,0 +1,87 @@
+package com.eventitta.auth.controller;
+
+import com.eventitta.auth.dto.request.SignUpRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.eventitta.common.constants.ValidationMessage.*;
+import static com.eventitta.common.exception.CommonErrorCode.INVALID_INPUT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("회원 통합 테스트")
+public class AuthIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원이 이메일, 비밀번호, 닉네임으로 회원가입하면 사용자 정보가 응답된다.")
+    void 회원가입_정상_요청_시_사용자_정보가_응답된다() throws Exception {
+        // given
+        var request = new SignUpRequest("test@example.com", "P@ssw0rd!", "tester");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.email").value("test@example.com"))
+            .andExpect(jsonPath("$.nickname").value("tester"));
+    }
+
+    @Test
+    @DisplayName("회원이 유효하지 않은 이메일로 회원가입하면 이메일 형식 오류 메시지가 반환된다.")
+    void 이메일_형식이_유효하지_않으면_에러를_응답한다() throws Exception {
+        var request = new SignUpRequest("invalid-email", "P@ssw0rd!", "tester");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("email: " + EMAIL))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @DisplayName("회원이 형식에 맞지 않는 비밀번호로 회원가입하면 비밀번호 정책 위반 메시지가 반환된다.")
+    void 비밀번호_형식이_유효하지_않으면_에러를_응답한다() throws Exception {
+        var request = new SignUpRequest("user@example.com", "1234", "tester");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("password: " + PASSWORD))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @DisplayName("회원이 허용되지 않은 형식의 닉네임으로 회원가입하면 닉네임 정책 위반 메시지가 반환된다.")
+    void 닉네임_형식이_유효하지_않으면_에러를_응답한다() throws Exception {
+        var request = new SignUpRequest("user@example.com", "P@ssw0rd!", "!@#");
+
+        mockMvc.perform(post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("nickname: " + NICKNAME))
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+}

--- a/src/test/java/com/eventitta/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/AuthServiceTest.java
@@ -1,0 +1,100 @@
+package com.eventitta.auth.service;
+
+import com.eventitta.IntegrationTestSupport;
+import com.eventitta.auth.dto.request.SignUpRequest;
+import com.eventitta.common.exception.CustomException;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static com.eventitta.auth.exception.SignUpErrorCode.CONFLICTED_EMAIL;
+import static com.eventitta.auth.exception.SignUpErrorCode.CONFLICTED_NICKNAME;
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("회원 인증/인가 비즈니스 로직 테스트")
+class AuthServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("회원가입 화면에서 필요한 정보를 입력하면 회원가입이 성공한다.")
+    @Test
+    void signUp() {
+        // given
+        SignUpRequest signUpRequest = createSignUpRequest("test@naver.com", "password1234!", "nickname12");
+
+        // when
+        authService.signUp(signUpRequest);
+
+        // then
+        List<User> users = userRepository.findAll();
+
+        assertThat(users).hasSize(1)
+            .extracting("email", "nickname")
+            .contains(tuple(signUpRequest.email(),
+                signUpRequest.nickname()));
+    }
+
+    @DisplayName("회원가입을 수행할 때 이메일이 중복되면 예외가 발생한다.")
+    @Test
+    void signUpDuplicatedEmail() {
+        // given
+        String duplicatedEmail = "test@naver.com";
+        User user = createUser(duplicatedEmail, "nickname1");
+        userRepository.save(user);
+        SignUpRequest signUpRequest = createSignUpRequest(duplicatedEmail, "password1234!", "nickname13");
+
+        // when & then
+        assertThatThrownBy(() -> authService.signUp(signUpRequest))
+            .isInstanceOf(CustomException.class)
+            .hasMessageContaining(CONFLICTED_EMAIL.defaultMessage());
+    }
+
+    @DisplayName("회원가입을 수행할 때 닉네임이 중복되면 예외가 발생한다.")
+    @Test
+    void signUpDuplicatedNickname() {
+        // given
+        String duplicatedNickname = "nickname1";
+        User user = createUser("test@naver.com", duplicatedNickname);
+        userRepository.save(user);
+        SignUpRequest signUpRequest = createSignUpRequest("test2@naver.com", "password1234!", duplicatedNickname);
+
+        // when & then
+        assertThatThrownBy(() -> authService.signUp(signUpRequest))
+            .isInstanceOf(CustomException.class)
+            .hasMessageContaining(CONFLICTED_NICKNAME.defaultMessage());
+    }
+
+    private User createUser(String email, String nickname) {
+        return User.builder()
+            .email(email)
+            .password(passwordEncoder.encode("testpassword123"))
+            .nickname(nickname)
+            .role(Role.USER)
+            .provider(Provider.LOCAL)
+            .build();
+    }
+
+    private SignUpRequest createSignUpRequest(String email, String password, String nickname) {
+        return new SignUpRequest(email, password, nickname);
+    }
+}

--- a/src/test/java/com/eventitta/config/AuditorAwareImplTest.java
+++ b/src/test/java/com/eventitta/config/AuditorAwareImplTest.java
@@ -1,5 +1,6 @@
 package com.eventitta.config;
 
+import com.eventitta.common.config.AuditorAwareImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class AuditorAwareImplTest {
     @DisplayName("익명 사용자(anonymousUser)로 인증된 경우 사용자 식별 결과가 없다")
     void anonymousUser_returnsEmpty() {
         SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("anonymousUser",null)
+            new UsernamePasswordAuthenticationToken("anonymousUser", null)
         );
         assertThat(auditor.getCurrentAuditor()).isEmpty();
     }
@@ -41,7 +42,7 @@ class AuditorAwareImplTest {
     void authenticated_returnsName() {
         List<GrantedAuthority> auths = List.of(new SimpleGrantedAuthority("ROLE_USER"));
         UsernamePasswordAuthenticationToken token =
-                new UsernamePasswordAuthenticationToken("alice", null, auths);
+            new UsernamePasswordAuthenticationToken("alice", null, auths);
 
         SecurityContextHolder.getContext().setAuthentication(token);
 


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?

- 회원가입 기능이 없어, 사용자가 이메일/비밀번호/닉네임을 입력해 회원가입할 수 있는 API가 필요했습니다.
- `@WebMvcTest` 환경에서 `POST /api/v1/auth/signup` 테스트 시 Spring Security의 CSRF 및 인증 필터로 인해 `401 Unauthorized` 오류가 발생했습니다.

---

## 🛠️ 어떻게 해결했나요?

- `AuthController` 및 `AuthService`를 생성하여 회원가입 API를 구현했습니다.
- 중복 이메일/닉네임에 대해 커스텀 예외를 발생시키고, `GlobalExceptionHandler`에서 통일된 응답 포맷을 제공하도록 했습니다.
- `SignUpRequest` DTO에 `@Valid`, `@Pattern` 등을 활용해 유효성 검증을 적용했습니다.
- 테스트에서 발생한 `401 Unauthorized` 문제는 `ControllerTestSupport` 클래스에 `@Import(SecurityConfig.class)`를 추가해 Security 설정을 명시적으로 반영함으로써 해결했습니다.

---

## ✨ 주요 변경사항

- `SignUpRequest`, `SignUpResponse` DTO 및 유효성 검증 로직 추가
- `AuthController` 구현 (`/api/v1/auth/signup`)
- `AuthService` 구현 및 중복 이메일/닉네임 체크 로직 포함
- 커스텀 예외 및 `GlobalExceptionHandler`를 통한 에러 응답 처리
- 컨트롤러 슬라이스 테스트 (`AuthControllerTest`)
- 통합 테스트 (`AuthIntegrationTest`, `AuthServiceTest`)
- 테스트용 시큐리티 설정 반영 (`@Import(SecurityConfig.class)`)

---

## ✅ 검증 시나리오

- [x] 유효한 입력 시 회원가입에 성공하고 사용자 정보 반환 (200 OK)
- [x] 이메일 형식이 잘못되면 400 Bad Request 및 검증 메시지 반환
- [x] 비밀번호 형식이 잘못되면 400 Bad Request 및 정책 위반 메시지 반환
- [x] 닉네임 형식이 잘못되면 400 Bad Request 및 정책 위반 메시지 반환
- [x] 중복 이메일로 회원가입 시 409 Conflict 및 중복 이메일 메시지 반환
- [x] 중복 닉네임으로 회원가입 시 409 Conflict 및 중복 닉네임 메시지 반환

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인

## 📎 첨부 (Attachment)
```mermaid
classDiagram
    class AuthController {
        +signUp(SignUpRequest): ResponseEntity
    }

    class AuthService {
        +signUp(SignUpRequest): User
    }

    class SignUpRequest {
        +email: String
        +password: String
        +nickname: String
        +toEntity(PasswordEncoder): User
    }

    class UserRepository {
        <<interface>>
        +existsByEmail(String): boolean
        +existsByNickname(String): boolean
        +save(User): User
    }

    class User {
        +id: Long
        +email: String
        +password: String
        +nickname: String
        +role: Role
        +provider: Provider
    }

    AuthController --> AuthService
    AuthService --> UserRepository
    AuthService --> User
    AuthController --> SignUpRequest
    SignUpRequest --> User

```

## 📚 참고 링크
* 컨트롤러 테스트 csrf: https://solidbasics.tistory.com/69
