### PR TITLE
Feat/유저 로그아웃

### DIFF
--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.eventitta.auth.dto.response.SignUpResponse;
 import com.eventitta.auth.service.AuthService;
 import com.eventitta.auth.service.SignUpService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,6 +53,22 @@ public class AuthController {
     ) {
         authService.refresh(accessToken, refreshToken, response);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 로그인 세션을 종료하고 토큰을 무효화합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @Parameter(in = ParameterIn.COOKIE, name = "access_token", description = "액세스 토큰")
+        @CookieValue(name = "access_token", required = false) String accessToken,
+        @Parameter(in = ParameterIn.COOKIE, name = "refresh_token", description = "리프레시 토큰")
+        @CookieValue(name = "refresh_token", required = false) String refreshToken,
+        HttpServletResponse response
+    ) {
+        authService.logout(accessToken, response);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/eventitta/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/eventitta/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,11 @@
 package com.eventitta.auth.repository;
 
 import com.eventitta.auth.domain.RefreshToken;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -10,4 +14,12 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUserId(Long userId);
 
     long deleteByExpiresAtBefore(LocalDateTime now);
+
+    @Modifying
+    @Transactional
+    @Query(
+        value = "DELETE FROM refresh_tokens WHERE user_id = :userId",
+        nativeQuery = true
+    )
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
@@ -37,4 +37,9 @@ public class RefreshTokenService {
 
         return tokenService.issueTokens(userId);
     }
+
+    public void invalidateByAccessToken(String accessToken) {
+        Long userId = tokenProvider.getUserIdFromExpiredToken(accessToken);
+        rtRepo.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/eventitta/common/config/ClockConfig.java
+++ b/src/main/java/com/eventitta/common/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package com.eventitta.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}
+

--- a/src/main/java/com/eventitta/common/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/eventitta/common/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.eventitta.common.config;
+
+import com.eventitta.auth.exception.AuthErrorCode;
+import com.eventitta.common.response.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ApiErrorResponse body = ApiErrorResponse.of(
+            AuthErrorCode.ACCESS_TOKEN_INVALID.name(),
+            AuthErrorCode.ACCESS_TOKEN_INVALID.defaultMessage(),
+            HttpStatus.UNAUTHORIZED.value(),
+            request.getRequestURI()
+        );
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/eventitta/common/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/common/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     @Primary
@@ -65,6 +66,7 @@ public class SecurityConfig {
                     .anyRequest().authenticated()
             )
             .authenticationProvider(authenticationProvider())
+            .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/eventitta/common/util/CookieUtil.java
+++ b/src/main/java/com/eventitta/common/util/CookieUtil.java
@@ -48,4 +48,13 @@ public final class CookieUtil {
                 .toString()
         );
     }
+
+    public static void deleteCookie(HttpServletResponse resp, String name) {
+        ResponseCookie c = ResponseCookie.from(name, "")
+            .httpOnly(true)
+            .path("/")
+            .maxAge(0)
+            .build();
+        resp.addHeader(HttpHeaders.SET_COOKIE, c.toString());
+    }
 }

--- a/src/test/java/com/eventitta/ControllerTestSupport.java
+++ b/src/test/java/com/eventitta/ControllerTestSupport.java
@@ -3,6 +3,7 @@ package com.eventitta;
 import com.eventitta.auth.controller.AuthController;
 import com.eventitta.auth.jwt.JwtTokenProvider;
 import com.eventitta.auth.service.*;
+import com.eventitta.common.config.CustomAuthenticationEntryPoint;
 import com.eventitta.common.config.SecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,4 +33,6 @@ public abstract class ControllerTestSupport {
     protected TokenService tokenService;
     @MockitoBean
     protected RefreshTokenService refreshService;
+    @MockitoBean
+    protected CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 }


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
* 사용자가 로그아웃 요청을 보냈을 때 액세스·리프레시 토큰을 무효화하고 쿠키를 삭제할 수 있어야 합니다.

## 🛠️ 어떻게 해결했나요?
1. **AuthController / AuthService / RefreshTokenService**
   - `POST /api/v1/auth/logout` 엔드포인트 추가  
   - 컨트롤러가 쿠키로 받은 `access_token`을 서비스에 위임하고 `204 No Content` 응답  
   - 서비스는 액세스 토큰으로 사용자 ID를 추출해 DB의 리프레시 토큰을 삭제(무효화)  
   - 토큰 검증 오류(만료, 변조)는 무시하고, 반드시 쿠키가 삭제되도록 처리  

2. **CookieUtil**
   - `deleteCookie(HttpServletResponse response, String name)` 메서드로 `access_token`과 `refresh_token` 쿠키를 만료시켜 제거  

3. **JwtTokenProvider & JwtAuthenticationFilter**
   - `Clock` 주입으로 단위 테스트에서 `Thread.sleep` 제거  
   - `validateAccessToken()`, `getUserId()` 로 구체적 예외를 던져 전역 예외 처리 또는 `AuthenticationEntryPoint` 로 위임  

4. **테스트 보강**
   - `AuthControllerTest` / `AuthIntegrationTest`: 로그아웃 시나리오 (유효 토큰·무토큰·잘못된 토큰) 추가  
   - `AuthServiceUnitTest` / `RefreshTokenServiceUnitTest`: 서비스 로직 단위 검증 (BDD 스타일)  
   - `JwtTokenProviderTest`: 고정 `Clock` 주입 후 유효/만료/비정상 토큰 테스트 안정화  
   - Slice 테스트에 `CustomAuthenticationEntryPoint` `@MockBean` 등록  

## ✨ 주요 변경사항
- `feat`: 로그아웃 기능 구현  
- `refactor`: `JwtTokenProvider`에 `Clock` 인젝션 추가 및 `JwtAuthenticationFilter` 예외 처리 강화  
- `test`: 로그아웃 시나리오 추가 (컨트롤러, 통합, 서비스 단위)  
- `test`: `JwtTokenProvider` 단위 테스트 (Clock 도입)  
- `test`: Slice 테스트에서 `AuthenticationEntryPoint` `MockBean` 설정  

## ✅ 검증 시나리오
- 로그아웃 성공 (`204 No Content`)  
- 로그아웃 시도 (토큰 없음 → 쿠키만 삭제)  
- 로그아웃 시도 (잘못된 토큰 → 무시하고 쿠키 삭제)  

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인  
- [ ] 변경 라인 수 300줄 이내 유지  
- [x] 테스트 모두 통과  

## 📎 첨부 (Attachment)

## 📚 참고 링크
- https://blog.letsdev.me/jwt-authentication
- https://blog.letsdev.me/jwt-authentication-issuing-concept?source=more_series_bottom_blogs
