### PR TITLE
feat: 지역 기반 게시글 엔티티

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # 이벤트있다 Eventitta
+
 - 이벤트있다(Eventitta)는 지역 기반 소셜 커뮤니티 플랫폼으로, 온라인 상에서 지역 주민들이 서로의 관심사와 정보를 공유하고,
 - 이를 바탕으로 오프라인 이벤트나 모임으로 자연스럽게 연결될 수 있는 환경을 제공하는 서비스입니다.
+
 ## 1. 프로젝트 개요
 
 * **제작 기간**: 2025-04-27 \~ (진행 중)
 * **참여 인원**: 1명 (개인 프로젝트)
 * **프로젝트 설명**:
-
 
 ## 2. 사용 기술 스택
 
@@ -17,156 +18,164 @@
 
 ## 3. 아키텍처 설계
 
-
 ## 4. 도메인 모델
 
 ## 5. 차트 & 다이어그램
+
 <details>
   <summary> ERD 보기/숨기기</summary>
 
 ```mermaid
 erDiagram
     USERS {
-        INT        id PK
-        VARCHAR    email
-        VARCHAR    paassword
-        VARCHAR    nickname
-        VARCHAR    profile_picture_url
-        TEXT       self_intro
-        VARCGAR    intersets
-        VARCHAR    address
-        DECIMAL    latitude
-        DECIMAL    longitude
-        ENUM       role
-        VARCHAR    provider
-        VARCHAR    provider_id
-        TIMESTAMP  created_at
-        TIMESTAMP  updated_at
+        INT id PK
+        VARCHAR email
+        VARCHAR password
+        VARCHAR nickname
+        VARCHAR profile_picture_url
+        TEXT self_intro
+        JSON interests
+        VARCHAR address
+        DECIMAL latitude
+        DECIMAL longitude
+        ENUM role
+        VARCHAR provider
+        VARCHAR provider_id
+        DATETIME created_at
+        DATETIME updated_at
     }
 
-    POST {
-        INT        id PK
-        INT        user_id FK
-        VARCHAR    title
-        TEXT       content
-        VARCHAR    location_label
-        DECIMAL    latitude
-        DECIMAL    longtitude
-        TIMESTAMP  created_at
-        TIMESTAMP  updated_at
+    REGION {
+        VARCHAR code PK
+        VARCHAR name
+        VARCHAR parent_code
+        INT level
     }
 
-    COMMENT {
-        INT        id PK
-        INT        post_id FK
-        INT        user_id FK
-        TEXT       comment
-        INT        parent_comment_id FK
-        TIMESTAMP  created_at
-        TIMESTAMP  updated_at
+    POSTS {
+        INT id PK
+        INT user_id FK
+        VARCHAR title
+        TEXT content
+        VARCHAR region_code FK
+        DATETIME created_at
+        DATETIME updated_at
     }
 
-    BADGE {
-        INT        id PK
-        VARCHAR    badge_name
-        INT        description
+    COMMENTS {
+        INT id PK
+        INT post_id FK
+        INT user_id FK
+        TEXT comment
+        INT parent_comment_id FK
+        DATETIME created_at
+        DATETIME updated_at
     }
 
-    USER_BADGE {
-        INT        id PK
-        INT        user_id FK
-        INT        badge_id FK
-        DATETIME   awarded_at
+    BADGES {
+        INT id PK
+        VARCHAR badge_name
+        TEXT description
+        VARCHAR criteria
+        DATETIME created_at
+        DATETIME updated_at
+    }
+
+    USER_BADGES {
+        INT id PK
+        INT user_id FK
+        INT badge_id FK
+        DATETIME awarded_at
     }
 
     ACTIVITY_TYPE {
-        INT        id PK
-        VARCHAR    code
-        VARCHAR    name
+        INT id PK
+        VARCHAR code
+        VARCHAR name
+        DATETIME created_at
+        DATETIME updated_at
     }
 
     USER_ACTIVITY {
-        INT        id PK
-        INT        activity_type_id FK
-        INT        user_id FK
-        INT        points
-        DATETIME   activity_date
+        INT id PK
+        INT activity_type_id FK
+        INT user_id FK
+        INT points
+        DATETIME activity_date
     }
 
-    MEETING {
-        INT        id PK
-        INT        user_id FK
-        VARCHAR    title
-        TEXT       description
-        DATETIME   start_time
-        DATETIME   end_time
-        INT        max_members
-        ENUM       status
-        VARCHAR    location_address
-        DECIMAL    latitude
-        DECIMAL    longtitude
-        TIMESTAMP  created_at
-        TIMESTAMP  updated_at
+    MEETINGS {
+        INT id PK
+        INT user_id FK
+        VARCHAR title
+        TEXT description
+        DATETIME start_time
+        DATETIME end_time
+        INT max_members
+        ENUM status
+        VARCHAR location_address
+        DECIMAL latitude
+        DECIMAL longitude
+        DATETIME created_at
+        DATETIME updated_at
     }
 
-    MEETING_PARTICIPANT {
-        INT        id PK
-        INT        meeting_id FK
-        INT        user_id FK
-        ENUM       join_status
-        TIMESTAMP  created_at
-        TIMESTAMP  updated_at
+    MEETING_PARTICIPANTS {
+        INT id PK
+        INT meeting_id FK
+        INT user_id FK
+        ENUM join_status
+        DATETIME created_at
+        DATETIME updated_at
     }
 
-    EVENT {
-        INT        id PK
-        VARCHAR    source
-        VARCHAR    title
-        VARCHAR    place
-        VARCHAR    address
-        TEXT       desciption
-        DATETIME   start_time
-        DATETIME   end_time
-        VARCHAR    location_address
-        DECIMAL    latitude
-        DECIMAL    longtitude
-        VARCHAR    category
-        VARCHAR    is_free
-        VARCHAR    use_fee
-        VARCHAR    hompage_url
-        VARCHAR    main_img_url
-        TIMESTAMP  updated_at
-        TIMESTAMP  created_at
+    EVENTS {
+        INT id PK
+        VARCHAR source
+        VARCHAR title
+        VARCHAR place
+        VARCHAR address
+        TEXT description
+        DATETIME start_time
+        DATETIME end_time
+        VARCHAR category
+        BOOLEAN is_free
+        VARCHAR use_fee
+        VARCHAR homepage_url
+        VARCHAR main_img_url
+        DATETIME created_at
+        DATETIME updated_at
     }
 
     REFRESH_TOKENS {
-        INT        id PK
-        INT        user_id FK
-        VARCHAR    token_hash
-        DATETIME   createdAt
-        DATETIME   expiresAt
+        INT id PK
+        INT user_id FK
+        VARCHAR token_hash
+        DATETIME created_at
+        DATETIME expires_at
     }
 
-    %%----------------- Relationships -----------------%%
-    USERS           ||--o{ POST               : writes
-    USERS           ||--o{ COMMENT            : writes
-    USERS           ||--o{ USER_BADGE         : receives
-    USERS           ||--o{ USER_ACTIVITY      : logs
-    USERS           ||--o{ MEETING            : hosts
-    USERS           ||--o{ MEETING_PARTICIPANT: joins
-    USERS           ||--o{ REFRESH_TOKENS     : has
-
-    POST            ||--o{ COMMENT            : contains
-    COMMENT         ||--o{ COMMENT            : replies_to
-    BADGE           ||--o{ USER_BADGE         : grants
-    ACTIVITY_TYPE   ||--o{ USER_ACTIVITY      : categorizes
-    MEETING         ||--o{ MEETING_PARTICIPANT: includes
+    USERS ||--o{ POSTS: "writes"
+    USERS ||--o{ COMMENTS: "writes"
+    USERS ||--o{ USER_BADGES: "receives"
+    USERS ||--o{ USER_ACTIVITY: "logs"
+    USERS ||--o{ MEETINGS: "hosts"
+    USERS ||--o{ MEETING_PARTICIPANTS: "joins"
+    USERS ||--o{ REFRESH_TOKENS: "owns"
+    REGION ||--o{ POSTS: "has posts"
+    POSTS ||--o{ COMMENTS: "contains"
+    COMMENTS ||--o{ COMMENTS: "replies_to"
+    BADGES ||--o{ USER_BADGES: "grants"
+    ACTIVITY_TYPE ||--o{ USER_ACTIVITY: "categorizes"
+    MEETINGS ||--o{ MEETING_PARTICIPANTS: "includes"
 ```
-</details> 
+
+</details>
 
 ## 6. 핵심 기능
 
 ## 7. Technical Issues & 고민 사항
+
 - 인증/인가 구현: 세션, 토큰 방식
 - Geo 검색 (위경도 기반 범위·거리 조회)
 

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -1,0 +1,9 @@
+package com.eventitta.post.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class PostController {
+}

--- a/src/main/java/com/eventitta/post/domain/Post.java
+++ b/src/main/java/com/eventitta/post/domain/Post.java
@@ -1,0 +1,37 @@
+package com.eventitta.post.domain;
+
+import com.eventitta.common.config.BaseEntity;
+import com.eventitta.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "region_code", nullable = false)
+    private Region region;
+}

--- a/src/main/java/com/eventitta/post/domain/Region.java
+++ b/src/main/java/com/eventitta/post/domain/Region.java
@@ -1,0 +1,29 @@
+package com.eventitta.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "region")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Region {
+    @Id
+    private String code;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "parent_code", length = 20)
+    private String parentCode;
+
+    private Integer level;
+}

--- a/src/main/java/com/eventitta/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/com/eventitta/post/dto/request/CreatePostRequest.java
@@ -1,0 +1,8 @@
+package com.eventitta.post.dto.request;
+
+public record CreatePostRequest(
+    String title,
+    String content,
+    String regionCode
+) {
+}

--- a/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
+++ b/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
@@ -1,0 +1,6 @@
+package com.eventitta.post.dto.response;
+
+public record CreatePostResponse(
+    Long id
+) {
+}

--- a/src/main/java/com/eventitta/post/repository/PostRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -1,0 +1,9 @@
+package com.eventitta.post.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class PostService {
+}


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 커뮤니티 게시판 API의 기본 골격(Controller/Service/Repository/DTO/Entity)이 아직 구현되지 않아, 기능 개발을 시작할 수 없습니다.  
- 구현 도중 커뮤니티 게시글을 등록할 때 사용자의 위/경도를 수집하는 것은 불필요하다고 생각했습니다.

## 🛠️ 어떻게 해결했나요?
- `PostController` 클래스 추가  
- `Post` 엔티티 정의 및 `Region` 연관 매핑 추가  
- `PostRepository` 인터페이스 추가  
- `PostService` 클래스 추가  
- `Region` 엔티티(JPA 매핑: code, name, parentCode, level) 추가  

## ✨ 주요 변경사항
- `Region` JPA 엔티티 추가  
- `Post` 엔티티에 `region` 연관관계 매핑  

###  Region 엔티티 필드 설명

| 필드 이름     | 타입      | 제약               | 설명                                                      |
|--------------|----------|--------------------|-----------------------------------------------------------|
| `code`       | `String` | PK, 길이 20        | 행정안전부 표준 10자리 코드 (예: `4111707300`). 지역 고유 식별자 |
| `name`       | `String` | NOT NULL, 길이 100 | 전체 명칭 (예: `경기도 용인시 기흥구 보정동`)               |
| `parentCode` | `String` | NULL 허용, 길이 20 | 상위 행정구역 코드 (레벨 1은 `null`)                       |
| `level`      | `Integer`| NOT NULL           | 행정구역 단계 (1=시·도, 2=시·군·구, 3=읍·면·동)           |

## ✅ 검증 시나리오
*

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인
- [x] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
- 일부 필드는 생략하였습니다.
```mermaid
erDiagram
    USERS {
        INT id PK
        VARCHAR email
    }

    REGION {
        VARCHAR code PK
        VARCHAR name
        VARCHAR parent_code
        INT level
    }

    POSTS {
        INT id PK
        INT user_id FK
        VARCHAR region_code FK
        VARCHAR title
    }

    USERS ||--o{ POSTS      : writes
    REGION ||--o{ POSTS     : located_in
```
## 📚 참고 링크
- https://www.data.go.kr/data/15092039/fileData.do?recommendDataYn=Y
