### PR TITLE
feat: 지역 기반 게시글 수정 기능

### DIFF
--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -2,18 +2,18 @@ package com.eventitta.post.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.dto.response.CreatePostResponse;
 import com.eventitta.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -23,13 +23,15 @@ import java.net.URI;
 @Tag(name = "지역기반 커뮤니티 API", description = "커뮤니티 게시글 API")
 @RequiredArgsConstructor
 public class PostController {
+
     private final PostService postService;
 
-
     @Operation(
-        summary = "게시글 생성",
-        description = "제목, 내용, 지역 코드로 새 게시글을 생성합니다."
+        summary = "게시글 생성"
     )
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "게시글 등록 성공"),
+    })
     @PostMapping
     public ResponseEntity<CreatePostResponse> create(
         @CurrentUser Long userId,
@@ -39,5 +41,21 @@ public class PostController {
         return ResponseEntity
             .created(URI.create("/api/v1/posts/" + postId))
             .body(new CreatePostResponse(postId));
+    }
+
+    @Operation(
+        summary = "게시글 수정"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "게시글 수정 성공"),
+    })
+    @PutMapping("/{postId}")
+    public ResponseEntity<Void> update(
+        @PathVariable("postId") Long postId,
+        @CurrentUser Long userId,
+        @RequestBody @Valid UpdatePostRequest request
+    ) {
+        postService.update(postId, userId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/eventitta/post/domain/Post.java
+++ b/src/main/java/com/eventitta/post/domain/Post.java
@@ -51,4 +51,10 @@ public class Post extends BaseEntity {
     ) {
         return new Post(user, title, content, region);
     }
+
+    public void update(String title, String content, Region region) {
+        this.title = title;
+        this.content = content;
+        this.region = region;
+    }
 }

--- a/src/main/java/com/eventitta/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/com/eventitta/post/dto/request/UpdatePostRequest.java
@@ -1,0 +1,19 @@
+package com.eventitta.post.dto.request;
+
+import com.eventitta.common.constants.ValidationMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "게시글 수정 요청")
+public record UpdatePostRequest(
+    @Schema(description = "게시글 제목", example = "지금 시간이 남아서")
+    @NotBlank(message = ValidationMessage.TITLE)
+    String title,
+    @Schema(description = "게시글 내용", example = "같이 드라이브하실 붐! 계신가용")
+    @NotBlank(message = ValidationMessage.CONTENT)
+    String content,
+    @Schema(description = "지역 코드", example = "1100110100")
+    @NotBlank(message = ValidationMessage.REGION_CODE)
+    String regionCode
+) {
+}

--- a/src/main/java/com/eventitta/post/exception/PostErrorCode.java
+++ b/src/main/java/com/eventitta/post/exception/PostErrorCode.java
@@ -1,0 +1,34 @@
+package com.eventitta.post.exception;
+
+import com.eventitta.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum PostErrorCode implements ErrorCode {
+    NOT_FOUND_POST_ID("해당 게시글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    ACCESS_DENIED("해당 게시글을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ;
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public PostException defaultException() {
+        return new PostException(this);
+    }
+
+    @Override
+    public PostException defaultException(Throwable cause) {
+        return new PostException(this, cause);
+    }
+}

--- a/src/main/java/com/eventitta/post/exception/PostException.java
+++ b/src/main/java/com/eventitta/post/exception/PostException.java
@@ -1,0 +1,14 @@
+package com.eventitta.post.exception;
+
+import com.eventitta.common.exception.CustomException;
+import com.eventitta.common.exception.ErrorCode;
+
+public class PostException extends CustomException {
+    public PostException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public PostException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -1,9 +1,11 @@
 package com.eventitta.post.service;
 
 import com.eventitta.post.domain.Post;
-import com.eventitta.region.domain.Region;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.repository.PostRepository;
+import com.eventitta.region.domain.Region;
+import com.eventitta.region.exception.RegionErrorCode;
 import com.eventitta.region.repository.RegionRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
@@ -11,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.eventitta.post.exception.PostErrorCode.ACCESS_DENIED;
+import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
 import static com.eventitta.region.exception.RegionErrorCode.NOT_FOUND_REGION_CODE;
 import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 
@@ -35,5 +39,18 @@ public class PostService {
             region
         );
         return postRepository.save(post).getId();
+    }
+
+    public void update(Long postId, Long userId, UpdatePostRequest request) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(NOT_FOUND_POST_ID::defaultException);
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw ACCESS_DENIED.defaultException();
+        }
+        Region region = regionRepository.findById(request.regionCode())
+            .orElseThrow(RegionErrorCode.NOT_FOUND_REGION_CODE::defaultException);
+
+        post.update(request.title(), request.content(), region);
     }
 }

--- a/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
@@ -2,7 +2,9 @@ package com.eventitta.post.controller;
 
 import com.eventitta.IntegrationTestSupport;
 import com.eventitta.WithMockCustomUser;
+import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;
 import com.eventitta.region.repository.RegionRepository;
@@ -20,8 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.eventitta.common.constants.ValidationMessage.*;
 import static com.eventitta.common.exception.CommonErrorCode.INVALID_INPUT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -140,5 +144,112 @@ public class PostControllerIntegrationTest extends IntegrationTestSupport {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("regionCode: " + REGION_CODE))
             .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 1L)
+    @DisplayName("게시글 수정 내용은 저장소에 정상적으로 반영된다")
+    void givenValidUpdateRequest_whenUpdatePost_thenReflectChanges() throws Exception {
+        // given
+        Post post = postRepository.save(Post.create(
+            userRepository.findById(testUserId).get(),
+            "old title", "old content",
+            regionRepository.findById("1100110100").get()
+        ));
+        Long postId = post.getId();
+
+        // when
+        UpdatePostRequest req = new UpdatePostRequest("new title", "new content", "1100110100");
+        mockMvc.perform(put("/api/v1/posts/{postId}", postId)
+                .cookie(buildAccessTokenCookie(testUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isNoContent());
+
+        // then
+        Post updated = postRepository.findById(postId).orElseThrow();
+        assertThat(updated.getTitle()).isEqualTo("new title");
+        assertThat(updated.getContent()).isEqualTo("new content");
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 1L)
+    @DisplayName("게시글 제목 없이는 수정할 수 없다")
+    void givenEmptyTitle_whenUpdatePost_thenBadRequest() throws Exception {
+        // given
+        Post post = postRepository.save(Post.create(
+            userRepository.findById(testUserId).get(),
+            "old", "old",
+            regionRepository.findById("1100110100").get()
+        ));
+        Long postId = post.getId();
+
+        // when & then
+        var badReq = new UpdatePostRequest("", "content", "1100110100");
+        mockMvc.perform(put("/api/v1/posts/{postId}", postId)
+                .cookie(buildAccessTokenCookie(testUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(badReq))
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 1L)
+    @DisplayName("존재하지 않는 지역으로는 게시글을 수정할 수 없다")
+    void givenNonexistentRegion_whenUpdatePost_thenNotFound() throws Exception {
+        // given
+        Post post = postRepository.save(Post.create(
+            userRepository.findById(testUserId).get(),
+            "old", "old",
+            regionRepository.findById("1100110100").get()
+        ));
+        Long postId = post.getId();
+
+        // when & then
+        var badReq = new UpdatePostRequest("title", "content", "0000000000");
+        mockMvc.perform(put("/api/v1/posts/{postId}", postId)
+                .cookie(buildAccessTokenCookie(testUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(badReq))
+            )
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 2L)
+    @DisplayName("작성자만 게시글을 수정할 수 있다")
+    void givenDifferentUser_whenUpdatePost_thenForbidden() throws Exception {
+        // given
+        Post post = postRepository.save(Post.create(
+            userRepository.findById(testUserId).get(),
+            "old", "old",
+            regionRepository.findById("1100110100").get()
+        ));
+        Long postId = post.getId();
+
+        // when & then
+        UpdatePostRequest req = new UpdatePostRequest("title", "content", "1100110100");
+        mockMvc.perform(put("/api/v1/posts/{postId}", postId)
+                .cookie(buildAccessTokenCookie(2L))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 1L)
+    @DisplayName("존재하지 않는 게시글은 수정할 수 없다")
+    void givenNotExistPost_whenUpdatePost_thenNotFound() throws Exception {
+        // when & then
+        var req = new UpdatePostRequest("title", "content", "1100110100");
+        mockMvc.perform(put("/api/v1/posts/{postId}", 9999L)
+                .cookie(buildAccessTokenCookie(testUserId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/eventitta/post/controller/PostControllerTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerTest.java
@@ -2,7 +2,9 @@ package com.eventitta.post.controller;
 
 import com.eventitta.ControllerTestSupport;
 import com.eventitta.WithMockCustomUser;
+import com.eventitta.common.constants.ValidationMessage;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.UpdatePostRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -12,8 +14,10 @@ import static com.eventitta.common.exception.CommonErrorCode.INVALID_INPUT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("동네 기반 게시글 컨트롤러 슬라이스 테스트")
@@ -100,5 +104,66 @@ class PostControllerTest extends ControllerTestSupport {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("regionCode: " + REGION_CODE))
             .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("올바른 데이터로 게시글 수정 시 성공적으로 수정된다.")
+    void givenValidUpdateRequest_whenUpdate_thenNoContent() throws Exception {
+        // given
+        UpdatePostRequest req = new UpdatePostRequest("새 제목", "새 내용", "1100110100");
+        doNothing().when(postService).update(eq(100L), eq(42L), any(UpdatePostRequest.class));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/posts/" + 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("제목 없이 수정 시 게시글 수정에 실패한다.")
+    void givenEmptyTitle_whenUpdate_thenBadRequest() throws Exception {
+        UpdatePostRequest req = new UpdatePostRequest("", "내용", "1100110100");
+
+        mockMvc.perform(put("/api/v1/posts/" + 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()))
+            .andExpect(jsonPath("$.message").value("title: " + ValidationMessage.TITLE));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("제목 없이 수정 시 게시글 수정에 실패한다.")
+    void givenEmptyContent_whenUpdate_thenBadRequest() throws Exception {
+        UpdatePostRequest req = new UpdatePostRequest("testTitle", "", "1100110100");
+
+        mockMvc.perform(put("/api/v1/posts/" + 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()))
+            .andExpect(jsonPath("$.message").value("content: " + CONTENT));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("제목 없이 수정 시 게시글 수정에 실패한다.")
+    void givenEmptyRegion_whenUpdate_thenBadRequest() throws Exception {
+        UpdatePostRequest req = new UpdatePostRequest("testTitle", "testContent", "");
+
+        mockMvc.perform(put("/api/v1/posts/" + 100L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value(INVALID_INPUT.toString()))
+            .andExpect(jsonPath("$.message").value("regionCode: " + REGION_CODE));
     }
 }

--- a/src/test/java/com/eventitta/post/service/PostServiceTest.java
+++ b/src/test/java/com/eventitta/post/service/PostServiceTest.java
@@ -2,6 +2,9 @@ package com.eventitta.post.service;
 
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.UpdatePostRequest;
+import com.eventitta.post.exception.PostErrorCode;
+import com.eventitta.post.exception.PostException;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;
 import com.eventitta.region.exception.RegionErrorCode;
@@ -26,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -39,6 +44,9 @@ class PostServiceTest {
 
     @InjectMocks
     PostService postService;
+
+    private final String VALID_REGION = "1100110100";
+    private final String INVALID_REGION = "0000000000";
 
     @Test
     @DisplayName("유효한 요청으로 생성 시 새 게시글 ID가 반환된다")
@@ -96,6 +104,95 @@ class PostServiceTest {
             .isEqualTo(RegionErrorCode.NOT_FOUND_REGION_CODE);
     }
 
+    @Test
+    @DisplayName("업데이트시 기존 게시물 및 소유자 및 유효한 지역이 주어지면 제목, 콘텐츠, 지역이 변경됩니다.")
+    void givenPostAndOwnerAndValidRegion_whenUpdate_thenFieldsUpdated() {
+        // given
+        final long POST_ID = 1L;
+        final long USER_ID = 10L;
+        Region region = createRegion(VALID_REGION);
+        Post post = spy(Post.create(
+            createUser(USER_ID, "test@test.com", "pw123123", "유저"),
+            "oldTitle", "oldContent",
+            region
+        ));
+        given(postRepository.findById(POST_ID))
+            .willReturn(Optional.of(post));
+        given(regionRepository.findById(VALID_REGION))
+            .willReturn(Optional.of(region));
+
+        UpdatePostRequest dto = createUpdateDto("newTitle", "newContent", VALID_REGION);
+
+        // when
+        postService.update(POST_ID, USER_ID, dto);
+
+        // then
+        verify(post).update("newTitle", "newContent", region);
+        assertThat(post.getTitle()).isEqualTo("newTitle");
+        assertThat(post.getContent()).isEqualTo("newContent");
+        assertThat(post.getRegion().getCode()).isEqualTo(VALID_REGION);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글을 수정 시 예외가 반환된다.")
+    void givenNoPost_whenUpdate_thenThrowNotFound() {
+        // given
+        final long POST_ID = 1L;
+        final long USER_ID = 10L;
+        given(postRepository.findById(POST_ID))
+            .willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() ->
+            postService.update(POST_ID, USER_ID, createUpdateDto("t", "c", VALID_REGION))
+        )
+            .isInstanceOf(PostException.class)
+            .extracting("errorCode")
+            .isEqualTo(PostErrorCode.NOT_FOUND_POST_ID);
+    }
+
+
+    @Test
+    @DisplayName("게시글의 소유자와 수정자가 다른 사용자이면 예외가 발생하는다.")
+    void givenPostOfOtherUser_whenUpdate_thenThrowAccessDenied() {
+        // given
+        final long POST_ID = 1L;
+        final long USER_ID = 10L;
+        final long OTHER_USER_ID = 20L;
+        User user = createUser(USER_ID, "test@test.com", "pw123123", "유저");
+        Post post = createPost(POST_ID, user, "title", createRegion(VALID_REGION));
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+
+        // when & then
+        assertThatThrownBy(() ->
+            postService.update(POST_ID, OTHER_USER_ID, createUpdateDto("t", "c", VALID_REGION))
+        )
+            .isInstanceOf(PostException.class)
+            .extracting("errorCode")
+            .isEqualTo(PostErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 지역 코드로 게시글을 수정 시 예외가 발생하는다.")
+    void givenInvalidRegion_whenUpdate_thenThrowRegionNotFound() {
+        // given
+        final long POST_ID = 1L;
+        final long USER_ID = 10L;
+        User user = createUser(USER_ID, "test@test.com", "pw123123", "유저");
+        Post post = createPost(POST_ID, user, "title", createRegion(INVALID_REGION));
+        given(postRepository.findById(POST_ID)).willReturn(Optional.of(post));
+
+        given(regionRepository.findById(INVALID_REGION)).willReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() ->
+            postService.update(POST_ID, USER_ID, createUpdateDto("t", "c", INVALID_REGION))
+        )
+            .isInstanceOf(RegionException.class)
+            .extracting("errorCode")
+            .isEqualTo(RegionErrorCode.NOT_FOUND_REGION_CODE);
+    }
+
     private static User createUser(long userId, String email, String password, String nickname) {
         return User.builder()
             .id(userId)
@@ -116,12 +213,16 @@ class PostServiceTest {
             .build();
     }
 
-    private static Post createPost(Long userId, User user, String title, Region region) {
+    private static Post createPost(Long postId, User user, String title, Region region) {
         return Post.builder()
-            .id(userId)
+            .id(postId)
             .user(user)
             .title(title)
             .region(region)
             .build();
+    }
+
+    private UpdatePostRequest createUpdateDto(String title, String content, String regionCode) {
+        return new UpdatePostRequest(title, content, regionCode);
     }
 }


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 기존에 게시글 수정 기능이 없어 사용자가 작성한 글(제목·내용·지역 코드)을 변경할 수 없습니다.  

## 🛠️ 어떻게 해결했나요?
- `PostController`에 `PUT /api/v1/posts/{postId}` 엔드포인트 추가  
- `PostService.update(postId, userId, dto)` 구현 
  - 게시글 존재 여부, 작성자 일치 체크(403), 지역 코드 검증(404)  
  - 성공 시 `Post` 엔티티의 `update` 호출  
  - 슬라이스 테스트(`PostControllerTest`)·통합 테스트(`PostControllerIntegrationTest`)·단위 테스트(`PostServiceTest`) 추가

## ✨ 주요 변경사항
- **Controller**  
  - `@PutMapping("/{postId}") public ResponseEntity<Void> update(...)` 추가  
- **DTO**  
  - `UpdatePostRequest`에 `@NotBlank` 검증 메시지 적용  
- **Service**  
  - `PostService.update(...)` 구현 (존재, 권한, 지역 검증 후 수정)  
- **Tests**  
  - 컨트롤러 슬라이스 테스트: 성공·유효성 실패·권한 실패·존재하지 않는 리소스 검증  
  - 통합 테스트: 실제 DB H2 환경에서 `PUT` 요청 후 DB 반영 확인  
  - 단위 테스트: `PostService.update()` 성공 케이스 및 예외 케이스 검증  

## ✅ 검증 시나리오
- 

## ⚙️ 머지 전 체크
- [ ] 코드 스타일/포맷팅 확인
- [ ] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
* 

## 📚 참고 링크
- 
