### PR TITLE
feat: 지역 기반 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -58,4 +58,19 @@ public class PostController {
         postService.update(postId, userId, request);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(
+        summary = "게시글 삭제"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "게시글 삭제 성공"),
+    })
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> delete(
+        @PathVariable("postId") Long postId,
+        @CurrentUser Long userId
+    ) {
+        postService.delete(postId, userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/eventitta/post/domain/Post.java
+++ b/src/main/java/com/eventitta/post/domain/Post.java
@@ -36,6 +36,9 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "region_code", nullable = false)
     private Region region;
 
+    @Column(nullable = false)
+    private boolean deleted = false;
+
     public Post(User user, String title, String content, Region region) {
         this.user = user;
         this.title = title;
@@ -56,5 +59,9 @@ public class Post extends BaseEntity {
         this.title = title;
         this.content = content;
         this.region = region;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/eventitta/post/repository/PostRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepository.java
@@ -3,5 +3,8 @@ package com.eventitta.post.repository;
 import com.eventitta.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -42,7 +42,7 @@ public class PostService {
     }
 
     public void update(Long postId, Long userId, UpdatePostRequest request) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
             .orElseThrow(NOT_FOUND_POST_ID::defaultException);
 
         if (!post.getUser().getId().equals(userId)) {
@@ -52,5 +52,14 @@ public class PostService {
             .orElseThrow(RegionErrorCode.NOT_FOUND_REGION_CODE::defaultException);
 
         post.update(request.title(), request.content(), region);
+    }
+
+    public void delete(Long postId, Long userId) {
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
+            .orElseThrow(NOT_FOUND_POST_ID::defaultException);
+        if (!post.getUser().getId().equals(userId)) {
+            throw ACCESS_DENIED.defaultException();
+        }
+        post.softDelete();
     }
 }


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 사용자가 작성한 게시글을 삭제할 수 있는 기능이 필요합니다.  
- 소프트 삭제(soft delete)로 처리하여 데이터는 보존하되, 일반 조회·수정·삭제 API에서는 삭제된 게시글이 노출되지 않도록 해야 합니다.

## 🛠️ 어떻게 해결했나요?
1. **엔티티**  
   - `Post`에 `boolean deleted` 필드를 추가하고, `softDelete()` 메서드로 플래그를 `true`로 변경하도록 구현했습니다.  
2. **Repository**  
   - `findByIdAndDeletedFalse` 메서드를 선언하여 “deleted=false” 게시글만 조회하도록 분리했습니다.  
3. **Service**  
   - `PostService.delete(postId, userId)` 메서드 구현  
     - `findByIdAndDeletedFalse(postId)` → 404 처리  
     - 작성자 검사 → 403 처리  
     - `post.softDelete()` 호출  
4. **Controller**  
   - `DELETE /api/v1/posts/{postId}` 엔드포인트 추가 → `204 No Content` 반환  
5. **테스트**  
   - **서비스 단위 테스트** (`PostServiceTest`):  
     - 정상 삭제 시 플래그 변경 검증  
     - 없는 게시글, 권한 없음 시 예외 검증  
   - **컨트롤러 슬라이스 테스트** (`PostControllerDeleteTest`):  
     - 성공(204), 404, 403 시나리오 검증  
   - **통합 테스트** (`PostControllerIntegrationTest`):  
     - 실제 DB(H2) 환경에서 삭제 호출 후 `deleted=true` 확인 및 HTTP 204, 404, 403 검증  

## ✨ 주요 변경사항
- `Post` 엔티티: `deleted` 필드 추가, `softDelete()` 메서드 구현  
- `PostRepository`: `Optional<Post> findByIdAndDeletedFalse(Long id)` 선언  
- `PostService`: `delete` 로직 추가 (조회·권한·플래그 변경)  
- `PostController`: `@DeleteMapping("/{postId}")` 추가  
- 테스트 인프라: 슬라이스·통합·단위 테스트 모두 보강 

## ✅ 검증 시나리오
1. **정상 삭제**  
   - 작성자가 본인 글 삭제 → HTTP 204 반환  
   - DB에서 `deleted=true` 확인  
2. **없는 게시글 삭제**  
   - 잘못된 `postId` → HTTP 404 반환  
3. **권한 없음**  
   - 다른 사용자 삭제 요청 → HTTP 403 반환  
4. **이후 조회**  
   - 삭제된 글은 `GET`, `PUT`, `DELETE` 모두 404 처리되는지(기존 테스트로 커버)  

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인
- [x] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
* 

## 📚 참고 링크
- 