### PR TITLE
feat(post); 지역 기반 게시글 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ java {
     }
 }
 
+def querydslVersion = '5.0.0'
+def querydslDir = 'src/main/generated'
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -46,6 +49,13 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+    runtimeOnly 'p6spy:p6spy:3.9.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
@@ -54,6 +64,25 @@ dependencies {
 
     // Spring Security Test
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    // Q 클래스 생성 위치 지정
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+// generated 폴더를 컴파일 소스에 포함
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslDir
+        }
+    }
+}
+
+// clean 시 생성 디렉터리 삭제
+clean.doLast {
+    delete querydslDir
 }
 
 tasks.named('test') {

--- a/src/main/java/com/eventitta/common/config/QuerydslConfig.java
+++ b/src/main/java/com/eventitta/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.eventitta.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/eventitta/common/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/common/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -61,8 +62,10 @@ public class SecurityConfig {
                         "/api/v1/auth/**",
                         "/v3/api-docs/**",
                         "/swagger-ui/**",
-                        "/swagger-ui.html")
+                        "/swagger-ui.html"
+                    )
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
                     .anyRequest().authenticated()
             )
             .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/eventitta/common/constants/ValidationMessage.java
+++ b/src/main/java/com/eventitta/common/constants/ValidationMessage.java
@@ -11,4 +11,9 @@ public final class ValidationMessage {
     public static final String TITLE = "게시글 제목을 입력해주세요.";
     public static final String CONTENT = "게시글 내용을 입력해주세요.";
     public static final String REGION_CODE = "지역을 입력해주세요.";
+    public static final String SEARCH_TYPE = "검색 타입을 지정해주세요.";
+    public static final String KEYWORD = "검색어를 입력해주세요.";
+    public static final String PAGE_MIN = "페이지 번호는 0 이상이어야 합니다.";
+    public static final String SIZE_MIN = "페이지 크기는 최소 1 이상이어야 합니다.";
+    public static final String SIZE_MAX = "페이지 크기는 최대 100 이하여야 합니다.";
 }

--- a/src/main/java/com/eventitta/common/response/PageResponse.java
+++ b/src/main/java/com/eventitta/common/response/PageResponse.java
@@ -1,12 +1,26 @@
 package com.eventitta.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "페이지네이션된 응답 모델")
 public record PageResponse<T>(
+
+    @Schema(description = "조회된 컨텐츠 리스트")
     List<T> content,
+
+    @Schema(description = "현재 페이지 번호", example = "0")
     int page,
+
+    @Schema(description = "페이지 크기", example = "10")
     int size,
+
+    @Schema(description = "전체 요소 개수", example = "123")
     long totalElements,
+
+    @Schema(description = "전체 페이지 수", example = "13")
     int totalPages
+
 ) {
 }

--- a/src/main/java/com/eventitta/common/response/PageResponse.java
+++ b/src/main/java/com/eventitta/common/response/PageResponse.java
@@ -1,0 +1,12 @@
+package com.eventitta.common.response;
+
+import java.util.List;
+
+public record PageResponse<T>(
+    List<T> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+}

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -1,7 +1,9 @@
 package com.eventitta.post.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
+import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.dto.response.CreatePostResponse;
 import com.eventitta.post.service.PostService;
@@ -16,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @Slf4j
 @RequestMapping("/api/v1/posts")
@@ -41,6 +44,19 @@ public class PostController {
         return ResponseEntity
             .created(URI.create("/api/v1/posts/" + postId))
             .body(new CreatePostResponse(postId));
+    }
+
+    @Operation(summary = "게시글 목록 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+    })
+    @GetMapping
+    public ResponseEntity<PageResponse<PostResponse>> getPosts(
+        @RequestParam(defaultValue = "0", name = "page") int page,
+        @RequestParam(defaultValue = "10", name = "size") int size
+    ) {
+        PageResponse<PostResponse> result = postService.getPosts(page, size);
+        return ResponseEntity.ok(result);
     }
 
     @Operation(

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -52,7 +52,7 @@ public class PostController {
     })
     @GetMapping
     public ResponseEntity<PageResponse<PostResponse>> getPosts(
-        PostFilter filter
+        @Valid PostFilter filter
     ) {
         PageResponse<PostResponse> result = postService.getPosts(filter);
         return ResponseEntity.ok(result);

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.eventitta.post.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
 import com.eventitta.common.response.PageResponse;
+import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
 import com.eventitta.post.dto.request.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
@@ -18,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.List;
 
 @Slf4j
 @RequestMapping("/api/v1/posts")
@@ -52,10 +52,9 @@ public class PostController {
     })
     @GetMapping
     public ResponseEntity<PageResponse<PostResponse>> getPosts(
-        @RequestParam(defaultValue = "0", name = "page") int page,
-        @RequestParam(defaultValue = "10", name = "size") int size
+        PostFilter filter
     ) {
-        PageResponse<PostResponse> result = postService.getPosts(page, size);
+        PageResponse<PostResponse> result = postService.getPosts(filter);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/eventitta/post/dto/PostFilter.java
+++ b/src/main/java/com/eventitta/post/dto/PostFilter.java
@@ -4,8 +4,6 @@ import com.eventitta.common.constants.ValidationMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import org.springdoc.core.annotations.ParameterObject;
 
 @Schema(description = "게시글 목록 조회를 위한 필터링 및 페이징 파라미터")
@@ -21,16 +19,13 @@ public record PostFilter(
     @Max(value = 100, message = ValidationMessage.SIZE_MAX)
     int size,
 
-    @Schema(description = "검색 타입 (TITLE, CONTENT, TITLE_CONTENT)", example = "TITLE_CONTENT", required = true)
-    @NotNull(message = ValidationMessage.SEARCH_TYPE)
+    @Schema(description = "검색 타입 (TITLE, CONTENT, TITLE_CONTENT)", example = "TITLE_CONTENT")
     SearchType searchType,
 
-    @Schema(description = "검색 키워드", example = "맛집", required = true)
-    @NotBlank(message = ValidationMessage.KEYWORD)
+    @Schema(description = "검색 키워드", example = "맛집")
     String keyword,
 
-    @Schema(description = "지역 코드", example = "1100110100", required = true)
-    @NotBlank(message = ValidationMessage.REGION_CODE)
+    @Schema(description = "지역 코드", example = "1100110100")
     String regionCode
 
 ) {

--- a/src/main/java/com/eventitta/post/dto/PostFilter.java
+++ b/src/main/java/com/eventitta/post/dto/PostFilter.java
@@ -1,0 +1,37 @@
+package com.eventitta.post.dto;
+
+import com.eventitta.common.constants.ValidationMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springdoc.core.annotations.ParameterObject;
+
+@Schema(description = "게시글 목록 조회를 위한 필터링 및 페이징 파라미터")
+@ParameterObject
+public record PostFilter(
+
+    @Schema(description = "페이지 번호 (0부터 시작)", example = "0", minimum = "0")
+    @Min(value = 0, message = ValidationMessage.PAGE_MIN)
+    int page,
+
+    @Schema(description = "페이지 크기", example = "10", minimum = "1", maximum = "100")
+    @Min(value = 1, message = ValidationMessage.SIZE_MIN)
+    @Max(value = 100, message = ValidationMessage.SIZE_MAX)
+    int size,
+
+    @Schema(description = "검색 타입 (TITLE, CONTENT, TITLE_CONTENT)", example = "TITLE_CONTENT", required = true)
+    @NotNull(message = ValidationMessage.SEARCH_TYPE)
+    SearchType searchType,
+
+    @Schema(description = "검색 키워드", example = "맛집", required = true)
+    @NotBlank(message = ValidationMessage.KEYWORD)
+    String keyword,
+
+    @Schema(description = "지역 코드", example = "1100110100", required = true)
+    @NotBlank(message = ValidationMessage.REGION_CODE)
+    String regionCode
+
+) {
+}

--- a/src/main/java/com/eventitta/post/dto/SearchType.java
+++ b/src/main/java/com/eventitta/post/dto/SearchType.java
@@ -1,0 +1,6 @@
+package com.eventitta.post.dto;
+
+public enum SearchType {
+    TITLE, CONTENT, TITLE_CONTENT
+}
+

--- a/src/main/java/com/eventitta/post/dto/request/PostResponse.java
+++ b/src/main/java/com/eventitta/post/dto/request/PostResponse.java
@@ -1,0 +1,25 @@
+package com.eventitta.post.dto.request;
+
+import com.eventitta.post.domain.Post;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+    Long id,
+    String title,
+    String content,
+    String regionCode,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    public static PostResponse from(Post p) {
+        return new PostResponse(
+            p.getId(),
+            p.getTitle(),
+            p.getContent(),
+            p.getRegion().getCode(),
+            p.getCreatedAt(),
+            p.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/eventitta/post/repository/PostRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepository.java
@@ -1,10 +1,14 @@
 package com.eventitta.post.repository;
 
 import com.eventitta.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndDeletedFalse(Long id);
+
+    Page<Post> findAllByDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/com/eventitta/post/repository/PostRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     Optional<Post> findByIdAndDeletedFalse(Long id);
 
     Page<Post> findAllByDeletedFalse(Pageable pageable);

--- a/src/main/java/com/eventitta/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.post.domain.Post;
+import com.eventitta.post.dto.PostFilter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+    Page<Post> findAllByFilter(PostFilter filter, Pageable pageable);
+}

--- a/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.post.domain.Post;
+import com.eventitta.post.domain.QPost;
+import com.eventitta.post.dto.PostFilter;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private final QPost post = QPost.post;
+
+    @Override
+    public Page<Post> findAllByFilter(PostFilter filter, Pageable pageable) {
+        BooleanBuilder predicate = buildFilter(filter);
+
+        List<Post> content = queryFactory
+            .selectFrom(post)
+            .where(predicate)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(post.createdAt.desc())
+            .fetch();
+
+        return PageableExecutionUtils.getPage(content, pageable,
+            () -> Objects.requireNonNullElse(
+                queryFactory
+                    .select(post.count())
+                    .from(post)
+                    .where(predicate)
+                    .fetchOne(),
+                0L
+            )
+        );
+    }
+
+    private BooleanBuilder buildFilter(PostFilter filter) {
+        BooleanBuilder b = new BooleanBuilder(post.deleted.isFalse());
+
+        if (filter.keyword() != null) {
+            String kw = filter.keyword().toLowerCase();
+            BooleanExpression titleCond = post.title.lower().like("%" + kw + "%");
+            BooleanExpression contentCond = lowerClobContains(post.content, kw);
+
+            switch (filter.searchType()) {
+                case TITLE -> b.and(titleCond);
+                case CONTENT -> b.and(contentCond);
+                case TITLE_CONTENT -> b.and(titleCond.or(contentCond));
+            }
+        }
+        if (filter.regionCode() != null) {
+            b.and(post.region.code.eq(filter.regionCode()));
+        }
+        return b;
+    }
+
+    private BooleanExpression lowerClobContains(Path<String> clob, String kw) {
+        return stringTemplate("lower(cast({0} as char))", clob).like("%" + kw + "%");
+    }
+}

--- a/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -49,7 +50,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     private BooleanBuilder buildFilter(PostFilter filter) {
         BooleanBuilder b = new BooleanBuilder(post.deleted.isFalse());
 
-        if (filter.keyword() != null) {
+        if (filter.searchType() != null
+            && StringUtils.hasText(filter.keyword())) {
+
             String kw = filter.keyword().toLowerCase();
             BooleanExpression titleCond = post.title.lower().like("%" + kw + "%");
             BooleanExpression contentCond = lowerClobContains(post.content, kw);

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -1,7 +1,9 @@
 package com.eventitta.post.service;
 
+import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.request.CreatePostRequest;
+import com.eventitta.post.dto.request.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;
@@ -10,8 +12,14 @@ import com.eventitta.region.repository.RegionRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.eventitta.post.exception.PostErrorCode.ACCESS_DENIED;
 import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
@@ -61,5 +69,22 @@ public class PostService {
             throw ACCESS_DENIED.defaultException();
         }
         post.softDelete();
+    }
+
+    public PageResponse<PostResponse> getPosts(int page, int size) {
+        Pageable pg = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<Post> posts = postRepository.findAllByDeletedFalse(pg);
+
+        List<PostResponse> postResponseList = posts.stream()
+            .map(PostResponse::from)
+            .toList();
+
+        return new PageResponse<>(
+            postResponseList,
+            posts.getNumber(),
+            posts.getSize(),
+            posts.getTotalElements(),
+            posts.getTotalPages()
+        );
     }
 }

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.eventitta.post.service;
 
 import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
+import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
 import com.eventitta.post.dto.request.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
@@ -71,9 +72,10 @@ public class PostService {
         post.softDelete();
     }
 
-    public PageResponse<PostResponse> getPosts(int page, int size) {
-        Pageable pg = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        Page<Post> posts = postRepository.findAllByDeletedFalse(pg);
+    public PageResponse<PostResponse> getPosts(PostFilter filter) {
+        Pageable pg = PageRequest.of(filter.page(), filter.size());
+
+        Page<Post> posts = postRepository.findAllByFilter(filter, pg);
 
         List<PostResponse> postResponseList = posts.stream()
             .map(PostResponse::from)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,15 +4,17 @@ spring:
       on-profile: local
 
   datasource:
-    url: jdbc:mysql://localhost:3306/eventitta?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:p6spy:mysql://localhost:3306/eventitta?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
     username: eventittaUser
     password: ${MYSQL_PASSWORD}
+    driver-class-name: com.p6spy.engine.spy.P6SpyDriver
 
   jpa:
     hibernate:
       ddl-auto: create
-    show-sql: true
     defer-datasource-initialization: true
+    properties:
+      hibernate.format_sql: true
 
   sql:
     init:
@@ -40,5 +42,6 @@ jwt:
 
 logging:
   level:
-    root: DEBUG
-    org.hibernate.SQL: DEBUG
+    root: INFO
+    org.hibernate.SQL: WARN
+    p6spy: DEBUG

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,3 @@
+module.log=com.p6spy.engine.spy.appender.Slf4JLogger
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logMessageFormat=com.p6spy.engine.spy.appender.MultiLineFormat

--- a/src/test/java/com/eventitta/post/repository/PostRepositoryImplTest.java
+++ b/src/test/java/com/eventitta/post/repository/PostRepositoryImplTest.java
@@ -1,0 +1,105 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.auth.repository.RefreshTokenRepository;
+import com.eventitta.common.config.QuerydslConfig;
+import com.eventitta.post.domain.Post;
+import com.eventitta.post.dto.PostFilter;
+import com.eventitta.post.dto.SearchType;
+import com.eventitta.region.domain.Region;
+import com.eventitta.region.repository.RegionRepository;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EntityScan(basePackages = "com.eventitta")
+class PostRepositoryIntegrationTest {
+
+    @Autowired
+    PostRepository repository;
+    @Autowired
+    RegionRepository regionRepo;
+    @Autowired
+    UserRepository userRepo;
+    @Autowired
+    RefreshTokenRepository rtRepo;
+
+    @BeforeEach
+    void setUp() {
+        Region r1 = regionRepo.save(new Region("1100110100", "청운효자동", "1100100000", 3));
+        User u1 = userRepo.save(
+            User.builder()
+                .email("a@b.com")
+                .password("testPassword")
+                .nickname("foo")
+                .provider(Provider.LOCAL)
+                .role(Role.USER)
+                .build()
+        );
+        for (int i = 0; i < 10; i++) {
+            String title = (i % 2 == 0 ? "맛집" : "산책") + " 게시글 " + i;
+            String content = (i % 3 == 0 ? "테스트" : "내용") + " 본문 " + i;
+            repository.save(Post.create(u1, title, content, r1));
+        }
+    }
+
+    @Test
+    @DisplayName("필터 없이 조회하면 모든 게시글이 페이징되어 반환된다")
+    void withoutFilter_returnsAllPaged() {
+        PostFilter f = new PostFilter(0, 5, null, null, null);
+        Page<Post> page = repository.findAllByFilter(f, Pageable.ofSize(5));
+        assertThat(page.getTotalElements()).isEqualTo(10);
+        assertThat(page.getContent()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("제목으로 필터링하면 해당 키워드가 포함된 게시글만 조회된다")
+    void filterByTitle_contains맛집() {
+        PostFilter f = new PostFilter(0, 10, SearchType.TITLE, "맛집", null);
+        List<String> titles = repository
+            .findAllByFilter(f, Pageable.ofSize(10))
+            .getContent()
+            .stream()
+            .map(Post::getTitle)
+            .toList();
+        assertThat(titles).allMatch(t -> t.contains("맛집"));
+    }
+
+    @Test
+    @DisplayName("제목+내용으로 검색하면 둘 중 하나라도 키워드가 포함된 게시글이 조회된다")
+    void filterByTitleOrContent_combined() {
+        PostFilter f = new PostFilter(0, 10, SearchType.TITLE_CONTENT, "테스트", null);
+        List<Post> results = repository.findAllByFilter(f, Pageable.ofSize(10)).getContent();
+        assertThat(results).allMatch(p ->
+            p.getTitle().contains("테스트") ||
+                p.getContent().contains("테스트")
+        );
+    }
+
+    @Test
+    @DisplayName("지역 코드로 필터링하면 해당 지역의 게시글만 조회된다")
+    void filterByRegionCode() {
+        PostFilter f = new PostFilter(0, 10, null, null, "1100110100");
+        assertThat(repository.findAllByFilter(f, Pageable.ofSize(10)).getTotalElements())
+            .isEqualTo(10);
+    }
+}


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 단순 page, size 페이징에서 벗어나 제목·내용·지역코드 기반의 동적 필터링 지원

## 🛠️ 어떻게 해결했나요?
- 동적 쿼리 작성 편의와 테스트 용이성을 위한 QueryDSL 도입
- PostRepositoryImpl 에서 BooleanBuilder 기반 동적 페이징·필터링 구현

## ✨ 주요 변경사항
- QueryDSL 도입: BooleanBuilder 와 stringTemplate 으로 CLOB 내용까지 소문자 LIKE 검색 지원
- total count 최적화: PageableExecutionUtils.getPage() 로 필요 시에만 count 쿼리 실행
- p6spy 설정: SQL + 바인딩 파라미터 로그 확인 가능
- 테스트 커버리지: 각 레이어별로 게시글 목록 조회 시나리오 검증

## ✅ 검증 시나리오
1.	필터 없이 조회 → 전체 게시글 페이징 반환
2.	제목 필터링 → 제목에 키워드 포함 게시글만
3.	내용 필터링 → 내용에 키워드 포함 게시글만
4.	제목+내용 통합 필터 → 둘 중 하나라도 포함한 게시글
5.	지역코드 필터링 → 해당 지역 게시글만
6.	page/size boundary 검증 → 음수/범위 초과 시 400 Bad Request
7.	인증 없이 조회 → 200 OK
8.	SQL 로그 확인 → p6spy 출력

## ⚙️ 머지 전 체크
- [ ] 코드 스타일/포맷팅 확인
- [ ] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## 📚 참고 링크
- QueryDSL 공식 문서: https://querydsl.com/
- p6spy GitHub: https://github.com/p6spy/p6spy;
- Spring Data PageableExecutionUtils: https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/PageableExecutionUtils.html
