### PR TITLE
feat: 지역 기반 게시글 상세

### DIFF
--- a/src/main/java/com/eventitta/common/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/common/config/SecurityConfig.java
@@ -65,7 +65,9 @@ public class SecurityConfig {
                         "/swagger-ui.html"
                     )
                     .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
+                    .requestMatchers(HttpMethod.GET
+                        , "/api/v1/posts"
+                        , "/api/v1/posts/**").permitAll()
                     .anyRequest().authenticated()
             )
             .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -58,6 +58,18 @@ public class PostController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "게시글 상세 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "게시글 상세보기 조회 성공"),
+    })
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> getPost(
+        @PathVariable("postId") Long postId
+    ) {
+        PostResponse result = postService.getPost(postId);
+        return ResponseEntity.ok(result);
+    }
+
     @Operation(
         summary = "게시글 수정"
     )

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,5 +87,11 @@ public class PostService {
             posts.getTotalElements(),
             posts.getTotalPages()
         );
+    }
+
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository.findByIdAndDeletedFalse(postId)
+            .orElseThrow(NOT_FOUND_POST_ID::defaultException);
+        return PostResponse.from(post);
     }
 }

--- a/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.eventitta.common.constants.ValidationMessage.*;
@@ -263,7 +264,7 @@ public class PostControllerIntegrationTest extends IntegrationTestSupport {
     @WithMockCustomUser(userId = 1L)
     @DisplayName("작성자는 자신의 게시글을 삭제할 수 있다")
     void givenExistingPost_whenDeletePost_thenSoftDeletedAndNoContent() throws Exception {
-        // given: initial post
+        // given
         Post post = postRepository.save(Post.create(
             userRepository.findById(testUserId).get(),
             "to delete", "content",
@@ -362,5 +363,28 @@ public class PostControllerIntegrationTest extends IntegrationTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").exists());
         }
+    }
+
+    @Test
+    @DisplayName("모든 사용자는 게시글을 조회할 수 있다.")
+    void givenAnyUser_whenGetPost_thenOk() throws Exception {
+        // given
+        String title = "title1234";
+        String content = "content! content! content!";
+        String regionCode = "1100110100";
+        Post post = postRepository.save(Post.create(
+            userRepository.findById(testUserId).get(),
+            title, content,
+            regionRepository.findById(regionCode).get()
+        ));
+        Long postId = post.getId();
+
+        // when & then
+        mockMvc.perform(get("/api/v1/posts/{postId}", postId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(postId))
+            .andExpect(jsonPath("$.title").value(title))
+            .andExpect(jsonPath("$.content").value(content))
+            .andExpect(jsonPath("$.regionCode").value(regionCode));
     }
 }

--- a/src/test/java/com/eventitta/post/controller/PostControllerTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerTest.java
@@ -283,4 +283,30 @@ class PostControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.error").exists());
         }
     }
+
+    @Test
+    @DisplayName("모든 사용자는 게시글을 조회할 수 있다.")
+    void givenAnyUser_whenGetPost_thenOk() throws Exception {
+        // given
+        long postId = 1L;
+        PostResponse dummy = new PostResponse(
+            postId,
+            "title",
+            "content",
+            "1100110101",
+            LocalDateTime.now(),
+            LocalDateTime.now()
+        );
+
+        given(postService.getPost(any(Long.class)))
+            .willReturn(dummy);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/posts/{postId}", postId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(postId))
+            .andExpect(jsonPath("$.title").value(dummy.title()))
+            .andExpect(jsonPath("$.content").value(dummy.content()))
+            .andExpect(jsonPath("$.regionCode").value(dummy.regionCode()));
+    }
 }

--- a/src/test/java/com/eventitta/post/service/PostServiceTest.java
+++ b/src/test/java/com/eventitta/post/service/PostServiceTest.java
@@ -308,6 +308,43 @@ class PostServiceTest {
         assertThat(response.totalPages()).isEqualTo(4);
     }
 
+    @Test
+    @DisplayName("존재하는 게시글을 조회하면 게시글이 조회된다")
+    void givenPostId_whenValidPostId_thenReturnPostResponse() {
+        // given
+        Long postId = 123L;
+        User author = createUser(10L, "a@b.com", "pw12345678", "nick");
+        Region region = createRegion("1100110100");
+        Post post = Post.create(author, "제목", "내용", region);
+
+        given(postRepository.findByIdAndDeletedFalse(postId))
+            .willReturn(Optional.of(post));
+
+        // when
+        PostResponse response = postService.getPost(postId);
+
+        // then
+        assertThat(response.id()).isEqualTo(post.getId());
+        assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.content()).isEqualTo("내용");
+        assertThat(response.regionCode()).isEqualTo("1100110100");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글을 조회하면 게시글을 조회할 수 없다.")
+    void whenPostNotFound_thenThrowPostException() {
+        // given
+        Long postId = 999L;
+        given(postRepository.findByIdAndDeletedFalse(postId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> postService.getPost(postId))
+            .isInstanceOf(PostException.class)
+            .extracting("errorCode")
+            .isEqualTo(PostErrorCode.NOT_FOUND_POST_ID);
+    }
+
     private static User createUser(long userId, String email, String password, String nickname) {
         return User.builder()
             .id(userId)


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 게시글 상세 조회 기능이 아직 구현되어 있지 않아, 클라이언트에서 특정 postId에 해당하는 게시글 정보를 가져올 수 없습니다.

## 🛠️ 어떻게 해결했나요?
- Service
  - PostService#getPost(Long postId) 구현
  - 존재하는 게시글은 조회 후 PostResponse로 매핑
- Controller
  - GET /api/v1/posts/{postId} 엔드포인트 추가
  - @Valid 및 기본 응답 포맷 적용

## ✨ 주요 변경사항
- PostService.getPost 메서드 추가
- PostController.getPost (@GetMapping("/{postId}")) 추가
- SecurityConfig 에 상세 조회 URL (/api/v1/posts/*) permitAll() 설정
- Service 단위 테스트 
- Controller 슬라이스 테스트 
- Controller 통합 테스트

## ✅ 검증 시나리오
- 존재하는 게시글을 조회하는 경우 -> 성공
- 존재하지 않는 게시글을 조회하는 경우 -> 실패(예외 처리)

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인
- [x] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)


## 📚 참고 링크

