### PR TITLE
feat(post): 게시글 응답 작성자 정보 추가

### DIFF
--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -4,7 +4,7 @@ import com.eventitta.auth.annotation.CurrentUser;
 import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.request.PostResponse;
+import com.eventitta.post.dto.response.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.dto.response.CreatePostResponse;
 import com.eventitta.post.service.PostService;

--- a/src/main/java/com/eventitta/post/dto/response/PostResponse.java
+++ b/src/main/java/com/eventitta/post/dto/response/PostResponse.java
@@ -1,4 +1,4 @@
-package com.eventitta.post.dto.request;
+package com.eventitta.post.dto.response;
 
 import com.eventitta.post.domain.Post;
 
@@ -9,6 +9,8 @@ public record PostResponse(
     String title,
     String content,
     String regionCode,
+    String authorNickname,
+    String authorProfileUrl,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
@@ -18,6 +20,8 @@ public record PostResponse(
             p.getTitle(),
             p.getContent(),
             p.getRegion().getCode(),
+            p.getUser().getNickname(),
+            p.getUser().getProfilePictureUrl(),
             p.getCreatedAt(),
             p.getUpdatedAt()
         );

--- a/src/main/java/com/eventitta/post/repository/PostRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepository.java
@@ -3,11 +3,13 @@ package com.eventitta.post.repository;
 import com.eventitta.post.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+    @EntityGraph(attributePaths = {"user"})
     Optional<Post> findByIdAndDeletedFalse(Long id);
 
     Page<Post> findAllByDeletedFalse(Pageable pageable);

--- a/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.eventitta.post.repository;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.domain.QPost;
 import com.eventitta.post.dto.PostFilter;
+import com.eventitta.region.domain.QRegion;
+import com.eventitta.user.domain.QUser;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -22,6 +24,8 @@ import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
 public class PostRepositoryImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QPost post = QPost.post;
+    private final QUser user = QUser.user;
+    private final QRegion region = QRegion.region;
 
     @Override
     public Page<Post> findAllByFilter(PostFilter filter, Pageable pageable) {
@@ -29,6 +33,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         List<Post> content = queryFactory
             .selectFrom(post)
+            .join(post.user, user).fetchJoin()
+            .join(post.region, region).fetchJoin()
             .where(predicate)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -4,7 +4,7 @@ import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.request.PostResponse;
+import com.eventitta.post.dto.response.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;

--- a/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerIntegrationTest.java
@@ -2,11 +2,8 @@ package com.eventitta.post.controller;
 
 import com.eventitta.IntegrationTestSupport;
 import com.eventitta.WithMockCustomUser;
-import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
-import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.request.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;
@@ -23,7 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.eventitta.common.constants.ValidationMessage.*;
@@ -31,7 +27,6 @@ import static com.eventitta.common.exception.CommonErrorCode.INVALID_INPUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/eventitta/post/controller/PostControllerTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerTest.java
@@ -4,10 +4,9 @@ import com.eventitta.ControllerTestSupport;
 import com.eventitta.WithMockCustomUser;
 import com.eventitta.common.constants.ValidationMessage;
 import com.eventitta.common.response.PageResponse;
-import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.request.PostResponse;
+import com.eventitta.post.dto.response.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.exception.PostErrorCode;
 import com.eventitta.post.exception.PostException;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.eventitta.common.constants.ValidationMessage.*;
@@ -294,6 +292,8 @@ class PostControllerTest extends ControllerTestSupport {
             "title",
             "content",
             "1100110101",
+            "nickname",
+            "profileUrl",
             LocalDateTime.now(),
             LocalDateTime.now()
         );
@@ -307,6 +307,8 @@ class PostControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.id").value(postId))
             .andExpect(jsonPath("$.title").value(dummy.title()))
             .andExpect(jsonPath("$.content").value(dummy.content()))
+            .andExpect(jsonPath("$.authorNickname").value(dummy.authorNickname()))
+            .andExpect(jsonPath("$.authorProfileUrl").value(dummy.authorProfileUrl()))
             .andExpect(jsonPath("$.regionCode").value(dummy.regionCode()));
     }
 }

--- a/src/test/java/com/eventitta/post/service/PostServiceTest.java
+++ b/src/test/java/com/eventitta/post/service/PostServiceTest.java
@@ -4,7 +4,7 @@ import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.request.PostResponse;
+import com.eventitta.post.dto.response.PostResponse;
 import com.eventitta.post.dto.request.UpdatePostRequest;
 import com.eventitta.post.exception.PostErrorCode;
 import com.eventitta.post.exception.PostException;


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- `PostResponse` DTO가 `request` 패키지에 있어 응답용 클래스 위치가 부적절했습니다.
- 응답에 작성자(닉네임, 프로필 URL) 정보가 빠져 있었습니다.
- `Post` 조회 시 lazy-loading된 `User` 때문에 N+1 쿼리 문제가 발생했습니다.

## 🛠️ 어떻게 해결했나요?
1. `PostResponse` DTO를  
   `com.eventitta.post.dto.request` → `com.eventitta.post.dto.response` 로 이동  
2. `PostResponse` 생성자에 `authorNickname`, `authorProfileUrl` 필드 추가  
3. QueryDSL 구현체(`PostRepositoryImpl`)에  
   ```java
   .selectFrom(post)
   .fetchJoin(post.user)  // fetch join 추가
4. `PostRepository` 인터페이스의 `findByIdAndDeletedFalse` 메서드에
   ```java
   @EntityGraph(attributePaths = "user")
   Optional<Post> findByIdAndDeletedFalse(Long id);
   ```
- 를 적용해 User를 한 번에 가져오도록 설정

## ✨ 주요 변경사항
- DTO 패키지 구조 리팩토링 (request → response)
- 응답에 작성자 정보(닉네임, 프로필 URL) 필드 추가
- QueryDSL 페치 조인(fetchJoin) 적용으로 목록 조회 N+1 해결
- @EntityGraph 적용으로 상세 조회 N+1 해결


## ✅ 검증 시나리오
- 게시글 목록 조회 API 호출 시
  - SQL 로그 한 번만 발생하는지 확인 
- 게시글 상세 조회 API 호출 시
  - SQL 로그 한 번만 발생하는지 확인

## ⚙️ 머지 전 체크
- [x] 코드 스타일/포맷팅 확인
- [x] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
* 이번 MR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

## 📚 참고 링크
- #15 기능 개선 이슈 (작성자 정보 추가)