### PR TITLE
feat: 사용자 프로필 기능

### DIFF
--- a/src/main/java/com/eventitta/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/eventitta/auth/service/CustomUserDetailsService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findActiveByEmail(email)
             .orElseThrow(NOT_FOUND_USER_EMAIL::defaultException);
         return new UserPrincipal(user);
     }

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.eventitta.user.controller;
+
+import com.eventitta.auth.annotation.CurrentUser;
+import com.eventitta.user.dto.UserProfileResponse;
+import com.eventitta.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserService userService;
+
+    @Operation(summary = "내 프로필 조회")
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getMyProfile(@CurrentUser Long userId) {
+        UserProfileResponse resp = userService.getProfile(userId);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.eventitta.user.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
+import com.eventitta.common.response.ApiErrorResponse;
 import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
 import com.eventitta.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,14 +24,24 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
 
-    @Operation(summary = "내 프로필 조회")
+    @Operation(summary = "내 프로필 조회", description = "인증된 사용자의 프로필 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로필 조회 성공", content = @Content(schema = @Schema(implementation = UserProfileResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @GetMapping("/me")
     public ResponseEntity<UserProfileResponse> getMyProfile(@CurrentUser Long userId) {
         UserProfileResponse resp = userService.getProfile(userId);
         return ResponseEntity.ok(resp);
     }
 
-    @Operation(summary = "내 프로필 수정")
+    @Operation(summary = "내 프로필 수정", description = "인증된 사용자의 프로필 정보를 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "프로필 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 (유효성 검사 실패)", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @PutMapping("/me")
     public ResponseEntity<Void> updateMyProfile(
         @CurrentUser Long userId,
@@ -38,16 +51,22 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "회원 탈퇴")
+    @Operation(summary = "회원 탈퇴", description = "인증된 사용자의 계정을 탈퇴 처리합니다. 데이터는 삭제되지 않고 'deleted' 상태로 변경됩니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMe(@CurrentUser Long userId) {
         userService.deleteUser(userId);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "비밀번호 변경")
+    @Operation(summary = "비밀번호 변경", description = "인증된 사용자의 비밀번호를 변경합니다. 현재 비밀번호를 확인 후 새 비밀번호로 교체합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "비밀번호 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "현재 비밀번호가 일치하지 않거나 새 비밀번호의 형식이 올바르지 않음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     @PutMapping("/me/password")
     public ResponseEntity<Void> changePassword(

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.eventitta.user.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
+import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
 import com.eventitta.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +42,19 @@ public class UserController {
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMe(@CurrentUser Long userId) {
         userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "비밀번호 변경 성공"),
+    })
+    @PutMapping("/me/password")
+    public ResponseEntity<Void> changePassword(
+        @CurrentUser Long userId,
+        @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        userService.changePassword(userId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -34,4 +34,11 @@ public class UserController {
         userService.updateProfile(userId, request);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(@CurrentUser Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -1,15 +1,15 @@
 package com.eventitta.user.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
+import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
 import com.eventitta.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사용자 API")
 @RestController
@@ -23,5 +23,15 @@ public class UserController {
     public ResponseEntity<UserProfileResponse> getMyProfile(@CurrentUser Long userId) {
         UserProfileResponse resp = userService.getProfile(userId);
         return ResponseEntity.ok(resp);
+    }
+
+    @Operation(summary = "내 프로필 수정")
+    @PutMapping("/me")
+    public ResponseEntity<Void> updateMyProfile(
+        @CurrentUser Long userId,
+        @RequestBody @Valid UpdateProfileRequest request
+    ) {
+        userService.updateProfile(userId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -73,4 +73,22 @@ public class User extends BaseEntity {
 
     @Column(name = "provider_id", length = 100)
     private String providerId;
+
+    public void updateProfile(
+        String nickname,
+        String profilePictureUrl,
+        String selfIntro,
+        List<String> interests,
+        String address,
+        BigDecimal latitude,
+        BigDecimal longitude
+    ) {
+        this.nickname = nickname;
+        this.profilePictureUrl = profilePictureUrl;
+        this.selfIntro = selfIntro;
+        this.interests = interests;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 }

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -74,6 +74,10 @@ public class User extends BaseEntity {
     @Column(name = "provider_id", length = 100)
     private String providerId;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean deleted = false;
+
     public void updateProfile(
         String nickname,
         String profilePictureUrl,
@@ -94,5 +98,9 @@ public class User extends BaseEntity {
 
     public void changePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    public void delete() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -91,4 +91,8 @@ public class User extends BaseEntity {
         this.latitude = latitude;
         this.longitude = longitude;
     }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/eventitta/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/eventitta/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,20 @@
+package com.eventitta.user.dto;
+
+import com.eventitta.common.constants.RegexPattern;
+import com.eventitta.common.constants.ValidationMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "비밀번호 변경 요청")
+public record ChangePasswordRequest(
+    @Schema(description = "현재 비밀번호")
+    @NotBlank(message = ValidationMessage.PASSWORD)
+    String currentPassword,
+
+    @Schema(description = "새 비밀번호", example = "P@ssw0rd!", pattern = RegexPattern.PASSWORD)
+    @NotBlank(message = ValidationMessage.PASSWORD)
+    @Pattern(regexp = RegexPattern.PASSWORD, message = ValidationMessage.PASSWORD)
+    String newPassword
+) {
+}

--- a/src/main/java/com/eventitta/user/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/eventitta/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,31 @@
+package com.eventitta.user.dto;
+
+import com.eventitta.common.constants.RegexPattern;
+import com.eventitta.common.constants.ValidationMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Schema(description = "프로필 수정 요청")
+public record UpdateProfileRequest(
+    @Schema(description = "닉네임", example = "홍길동")
+    @NotBlank(message = ValidationMessage.NICKNAME)
+    @Pattern(regexp = RegexPattern.NICKNAME, message = ValidationMessage.NICKNAME)
+    String nickname,
+    @Schema(description = "프로필 이미지 URL")
+    String profilePictureUrl,
+    @Schema(description = "자기 소개")
+    String selfIntro,
+    @Schema(description = "관심사")
+    List<String> interests,
+    @Schema(description = "주소")
+    String address,
+    @Schema(description = "위도")
+    BigDecimal latitude,
+    @Schema(description = "경도")
+    BigDecimal longitude
+) {
+}

--- a/src/main/java/com/eventitta/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/eventitta/user/dto/UserProfileResponse.java
@@ -1,0 +1,54 @@
+package com.eventitta.user.dto;
+
+import com.eventitta.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Schema(description = "사용자 프로필 응답")
+public record UserProfileResponse(
+    @Schema(description = "사용자 ID")
+    Long id,
+    @Schema(description = "이메일")
+    String email,
+    @Schema(description = "닉네임")
+    String nickname,
+    @Schema(description = "프로필 이미지 URL")
+    String profilePictureUrl,
+    @Schema(description = "자기 소개")
+    String selfIntro,
+    @Schema(description = "관심사")
+    List<String> interests,
+    @Schema(description = "주소")
+    String address,
+    @Schema(description = "위도")
+    BigDecimal latitude,
+    @Schema(description = "경도")
+    BigDecimal longitude
+) {
+    public UserProfileResponse {
+        profilePictureUrl = Objects.requireNonNullElse(profilePictureUrl, "");
+        selfIntro = Objects.requireNonNullElse(selfIntro, "");
+        interests = interests != null ? interests : new ArrayList<>();
+        address = Objects.requireNonNullElse(address, "");
+        latitude = Objects.requireNonNullElse(latitude, BigDecimal.ZERO);
+        longitude = Objects.requireNonNullElse(longitude, BigDecimal.ZERO);
+    }
+
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(
+            user.getId(),
+            user.getEmail(),
+            user.getNickname(),
+            user.getProfilePictureUrl(),
+            user.getSelfIntro(),
+            user.getInterests(),
+            user.getAddress(),
+            user.getLatitude(),
+            user.getLongitude()
+        );
+    }
+}

--- a/src/main/java/com/eventitta/user/exception/UserErrorCode.java
+++ b/src/main/java/com/eventitta/user/exception/UserErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
     NOT_FOUND_USER_ID("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CURRENT_PASSWORD("현재 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    CONFLICTED_NICKNAME("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     DEFAULT("예상치 못한 서버 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;

--- a/src/main/java/com/eventitta/user/exception/UserErrorCode.java
+++ b/src/main/java/com/eventitta/user/exception/UserErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
     NOT_FOUND_USER_ID("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_CURRENT_PASSWORD("현재 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     DEFAULT("예상치 못한 서버 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;

--- a/src/main/java/com/eventitta/user/repository/UserRepository.java
+++ b/src/main/java/com/eventitta/user/repository/UserRepository.java
@@ -1,8 +1,9 @@
 package com.eventitta.user.repository;
 
 import com.eventitta.user.domain.User;
-import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +13,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    @Query("select u from User u where u.email = :email and u.deleted = false")
+    Optional<User> findActiveByEmail(@Param("email") String email);
+
+    @Query("select u from User u where u.id = :id and u.deleted = false")
+    Optional<User> findActiveById(@Param("id") Long id);
 }

--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
     public void deleteUser(Long userId) {
         User user = userRepository.findActiveById(userId)
             .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
-        userRepository.delete(user);
+        user.delete();
     }
 
     @Transactional

--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.eventitta.user.service;
 
 import com.eventitta.user.domain.User;
+import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
 import com.eventitta.user.exception.UserErrorCode;
 import com.eventitta.user.repository.UserRepository;
@@ -18,5 +19,20 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
         return UserProfileResponse.from(user);
+    }
+
+    @Transactional
+    public void updateProfile(Long userId, UpdateProfileRequest req) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
+        user.updateProfile(
+            req.nickname(),
+            req.profilePictureUrl(),
+            req.selfIntro(),
+            req.interests(),
+            req.address(),
+            req.latitude(),
+            req.longitude()
+        );
     }
 }

--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -1,11 +1,13 @@
 package com.eventitta.user.service;
 
 import com.eventitta.user.domain.User;
+import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
 import com.eventitta.user.exception.UserErrorCode;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public UserProfileResponse getProfile(Long userId) {
         User user = userRepository.findById(userId)
@@ -41,5 +44,14 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
         userRepository.delete(user);
+    }
+
+    public void changePassword(Long userId, ChangePasswordRequest req) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
+        if (!passwordEncoder.matches(req.currentPassword(), user.getPassword())) {
+            throw UserErrorCode.INVALID_CURRENT_PASSWORD.defaultException();
+        }
+        user.changePassword(passwordEncoder.encode(req.newPassword()));
     }
 }

--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -35,4 +35,11 @@ public class UserService {
             req.longitude()
         );
     }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -1,0 +1,22 @@
+package com.eventitta.user.service;
+
+import com.eventitta.user.domain.User;
+import com.eventitta.user.dto.UserProfileResponse;
+import com.eventitta.user.exception.UserErrorCode;
+import com.eventitta.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserProfileResponse getProfile(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
+        return UserProfileResponse.from(user);
+    }
+}

--- a/src/test/java/com/eventitta/ControllerTestSupport.java
+++ b/src/test/java/com/eventitta/ControllerTestSupport.java
@@ -11,6 +11,8 @@ import com.eventitta.common.storage.FileStorageService;
 import com.eventitta.file.controller.FileUploadController;
 import com.eventitta.post.controller.PostController;
 import com.eventitta.post.service.PostService;
+import com.eventitta.user.controller.UserController;
+import com.eventitta.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -23,7 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
     AuthController.class,
     PostController.class,
     FileUploadController.class,
-    CommentController.class
+    CommentController.class,
+    UserController.class
 })
 @AutoConfigureMockMvc(addFilters = false)
 @Import({SecurityConfig.class})
@@ -52,4 +55,6 @@ public abstract class ControllerTestSupport {
     protected FileStorageService storageService;
     @MockitoBean
     protected CommentService commentService;
+    @MockitoBean
+    protected UserService userService;
 }

--- a/src/test/java/com/eventitta/auth/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/CustomUserDetailsServiceTest.java
@@ -41,7 +41,7 @@ class CustomUserDetailsServiceTest {
             .role(Role.USER)
             .provider(Provider.LOCAL)
             .build();
-        given(userRepository.findByEmail("test@example.com"))
+        given(userRepository.findActiveByEmail("test@example.com"))
             .willReturn(Optional.of(user));
 
         UserDetails details = service.loadUserByUsername("test@example.com");
@@ -53,7 +53,7 @@ class CustomUserDetailsServiceTest {
     @Test
     @DisplayName("존재하지 않는 이메일을 입력하면 사용자를 찾을 수 없다는 오류가 발생한다")
     void loadUserByUsername_notFound_throws() {
-        given(userRepository.findByEmail("none@none.com"))
+        given(userRepository.findActiveByEmail("none@none.com"))
             .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.loadUserByUsername("none@none.com"))

--- a/src/test/java/com/eventitta/user/controller/UserControllerTest.java
+++ b/src/test/java/com/eventitta/user/controller/UserControllerTest.java
@@ -1,0 +1,127 @@
+package com.eventitta.user.controller;
+
+import com.eventitta.ControllerTestSupport;
+import com.eventitta.WithMockCustomUser;
+import com.eventitta.common.constants.ValidationMessage;
+import com.eventitta.user.dto.ChangePasswordRequest;
+import com.eventitta.user.dto.UpdateProfileRequest;
+import com.eventitta.user.dto.UserProfileResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("사용자 컨트롤러 슬라이스 테스트")
+class UserControllerTest extends ControllerTestSupport {
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("내 프로필을 조회하면 정보가 반환된다")
+    void getMyProfile_returnsProfile() throws Exception {
+        UserProfileResponse resp = new UserProfileResponse(
+            42L,
+            "user@test.com",
+            "nick",
+            "",
+            "",
+            List.of("a"),
+            "addr",
+            BigDecimal.ONE,
+            BigDecimal.TEN
+        );
+        given(userService.getProfile(42L)).willReturn(resp);
+
+        mockMvc.perform(get("/api/v1/users/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(42L))
+            .andExpect(jsonPath("$.email").value(resp.email()));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("프로필 수정시 성공하면 204가 반환된다")
+    void updateProfile_returnsNoContent() throws Exception {
+        UpdateProfileRequest req = new UpdateProfileRequest(
+            "nick",
+            null,
+            null,
+            List.of(),
+            null,
+            null,
+            null
+        );
+        doNothing().when(userService).updateProfile(eq(42L), any(UpdateProfileRequest.class));
+
+        mockMvc.perform(put("/api/v1/users/me")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("닉네임이 비어있으면 수정 요청이 거부된다")
+    void updateProfile_blankNickname_returnsBadRequest() throws Exception {
+        UpdateProfileRequest bad = new UpdateProfileRequest(
+            " ",
+            null,
+            null,
+            List.of(),
+            null,
+            null,
+            null
+        );
+
+        mockMvc.perform(put("/api/v1/users/me")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bad)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("nickname: " + ValidationMessage.NICKNAME));
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("회원 탈퇴시 204가 반환된다")
+    void deleteMe_returnsNoContent() throws Exception {
+        doNothing().when(userService).deleteUser(42L);
+
+        mockMvc.perform(delete("/api/v1/users/me"))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("비밀번호 변경 성공 시 204가 반환된다")
+    void changePassword_returnsNoContent() throws Exception {
+        ChangePasswordRequest req = new ChangePasswordRequest("oldPw123!", "NewPw123!");
+        doNothing().when(userService).changePassword(eq(42L), any(ChangePasswordRequest.class));
+
+        mockMvc.perform(put("/api/v1/users/me/password")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockCustomUser(userId = 42L)
+    @DisplayName("새 비밀번호 형식이 올바르지 않으면 400을 반환한다")
+    void changePassword_invalidNewPassword_returnsBadRequest() throws Exception {
+        ChangePasswordRequest bad = new ChangePasswordRequest("oldPw123!", "bad");
+
+        mockMvc.perform(put("/api/v1/users/me/password")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(bad)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("newPassword: " + ValidationMessage.PASSWORD));
+    }
+}

--- a/src/test/java/com/eventitta/user/service/UserServiceTest.java
+++ b/src/test/java/com/eventitta/user/service/UserServiceTest.java
@@ -1,0 +1,123 @@
+package com.eventitta.user.service;
+
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.dto.ChangePasswordRequest;
+import com.eventitta.user.dto.UpdateProfileRequest;
+import com.eventitta.user.dto.UserProfileResponse;
+import com.eventitta.user.exception.UserErrorCode;
+import com.eventitta.user.exception.UserException;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    UserService userService;
+
+    private User createUser(Long id) {
+        return User.builder()
+            .id(id)
+            .email("u" + id + "@test.com")
+            .password("encoded")
+            .nickname("nick" + id)
+            .role(Role.USER)
+            .provider(Provider.LOCAL)
+            .build();
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 프로필을 조회하면 사용자 프로필 정보를 반환한다")
+    void getProfile_returnsDto() {
+        User user = createUser(1L);
+        given(userRepository.findActiveById(1L)).willReturn(Optional.of(user));
+
+        UserProfileResponse resp = userService.getProfile(1L);
+
+        assertThat(resp.id()).isEqualTo(1L);
+        assertThat(resp.email()).isEqualTo(user.getEmail());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 프로필 조회 시 예외가 발생한다")
+    void getProfile_userNotFound_throws() {
+        given(userRepository.findActiveById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getProfile(1L))
+            .isInstanceOf(UserException.class)
+            .extracting("errorCode")
+            .isEqualTo(UserErrorCode.NOT_FOUND_USER_ID);
+    }
+
+    @Test
+    @DisplayName("닉네임이 이미 존재하면 프로필 수정에 실패한다")
+    void updateProfile_conflictNickname_throws() {
+        User user = createUser(1L);
+        UpdateProfileRequest req = new UpdateProfileRequest(
+            "newNick",
+            null,
+            null,
+            List.of(),
+            null,
+            null,
+            null
+        );
+        given(userRepository.findActiveById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname("newNick")).willReturn(true);
+
+        assertThatThrownBy(() -> userService.updateProfile(1L, req))
+            .isInstanceOf(UserException.class)
+            .extracting("errorCode")
+            .isEqualTo(UserErrorCode.CONFLICTED_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 틀리면 비밀번호 변경에 실패한다")
+    void changePassword_wrongCurrent_throws() {
+        User user = createUser(1L);
+        ChangePasswordRequest req = new ChangePasswordRequest("cur", "newPassword1!");
+        given(userRepository.findActiveById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("cur", user.getPassword())).willReturn(false);
+
+        assertThatThrownBy(() -> userService.changePassword(1L, req))
+            .isInstanceOf(UserException.class)
+            .extracting("errorCode")
+            .isEqualTo(UserErrorCode.INVALID_CURRENT_PASSWORD);
+    }
+
+    @Test
+    @DisplayName("정상적인 요청으로 비밀번호 변경에 성공한다")
+    void changePassword_success() {
+        User user = createUser(1L);
+        ChangePasswordRequest req = new ChangePasswordRequest("cur", "newPassword1!");
+        given(userRepository.findActiveById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("cur", user.getPassword())).willReturn(true);
+        given(passwordEncoder.encode("newPassword1!")).willReturn("encodedNew");
+
+        userService.changePassword(1L, req);
+
+        verify(userRepository).findActiveById(1L);
+        assertThat(user.getPassword()).isEqualTo("encodedNew");
+    }
+}


### PR DESCRIPTION
<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?
- 사용자 프로필 조회·수정, 비밀번호 변경, 계정 삭제 기능이 통합되어 있지 않아 관리가 분산되어 있음  
- 닉네임 중복, 잘못된 현재 비밀번호 처리, 계정 삭제(soft delete) 로직 부재로 인한 예외 처리 미흡  

## 🛠️ 어떻게 해결했나요?
- `UserController`에 프로필 조회, 프로필 수정, 비밀번호 변경, 계정 삭제 API 추가  
- `UserService`에 닉네임 중복 체크, 현재 비밀번호 검증, soft delete 처리 등 비즈니스 로직 구현  
- `User` 엔티티에 `deleted` 필드 추가 및 프로필 업데이트·비밀번호 변경·계정 삭제용 메서드 도입  
- `UpdateProfileRequest`, `ChangePasswordRequest`, `UserProfileResponse` DTO 생성 및 `@Valid` 검증 애노테이션 적용  
- `UserErrorCode`에 잘못된 비밀번호(`INVALID_PASSWORD`), 닉네임 충돌(`NICKNAME_CONFLICT`) 에러 코드 추가  
- `UserRepository`에 활성 사용자만 조회하는 `findActiveByEmail`, `findActiveById` 커스텀 메서드 추가  
- 단위 테스트·통합 테스트 작성하여 정상·예외 케이스 모두 검증  
- `ControllerTestSupport`에 `UserController` 테스트 지원 환경 업데이트  

## ✨ 주요 변경사항
- **컨트롤러**:  
  - `/api/v1/users/me` (GET) 프로필 조회  
  - `/api/v1/users/me` (PUT) 프로필 수정  
  - `/api/v1/users/me/password` (PUT) 비밀번호 변경  
  - `/api/v1/users/me` (DELETE) 계정 삭제  
- **서비스**:  
  - 닉네임 중복·비밀번호 검증 로직  
  - 삭제 대신 `deleted = true` 처리(soft delete)  
- **도메인**:  
  - `User.deleted` 플래그 추가  
  - `updateProfile()`, `changePassword()`, `deleteAccount()` 메서드 추가  
- **DTO & Validation**:  
  - 입력 DTO에 `@NotBlank`, `@Size`, `@Pattern` 등 검증 애노테이션 적용  
  - 응답 DTO에서 필드 누락 방지 및 일관된 구조 보장  
- **리포지토리**:  
  - `findActiveByEmail()`, `findActiveById()` 메서드 추가  
- **테스트**:  
  - 정상·예외 흐름 커버하는 단위·통합 테스트 추가  
  - `ControllerTestSupport`에 `UserController` 목(Mock) 설정  

## ✅ 검증 시나리오
- [x] 프로필 조회 정상 응답 확인  
- [ ] 프로필 수정 후 변경된 정보 반영 확인  
- [ ] 닉네임 중복 시 409(CONFLICT) 반환 확인  
- [ ] 현재 비밀번호 불일치 시 400(BAD_REQUEST) 반환 확인  
- [ ] 비밀번호 변경 후 로그인 성공 여부 확인  
- [ ] 계정 삭제 요청 시 `deleted=true` 처리 및 이후 조회 불가 확인  
- [ ] 삭제된 계정으로 로그인 시 404(NOT_FOUND) 반환 확인  

## ⚙️ 머지 전 체크
- [ ] 코드 스타일·포맷팅 확인  
- [ ] 변경 라인 수 300줄 이내 유지  

## 📎 첨부 (Attachment)


## 📚 참고 링크

