### PR TITLE
feat: 포인트 뱃지 기능

### DIFF
--- a/src/main/java/com/eventitta/comment/service/CommentService.java
+++ b/src/main/java/com/eventitta/comment/service/CommentService.java
@@ -36,7 +36,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final UserActivityService userActivityService;
 
-    public void writeComment(Long postId, Long userId, String content, Long parentCommentId) {
+    public List<String> writeComment(Long postId, Long userId, String content, Long parentCommentId) {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new PostException(NOT_FOUND_POST_ID));
         User user = userRepository.findById(userId)
@@ -57,7 +57,7 @@ public class CommentService {
 
         Comment savedComment = commentRepository.save(comment);
 
-        userActivityService.recordActivity(userId, CREATE_COMMENT, savedComment.getId());
+        return userActivityService.recordActivity(userId, CREATE_COMMENT, savedComment.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/eventitta/comment/service/CommentService.java
+++ b/src/main/java/com/eventitta/comment/service/CommentService.java
@@ -55,9 +55,9 @@ public class CommentService {
             .parent(parent)
             .build();
 
-        commentRepository.save(comment);
+        Comment savedComment = commentRepository.save(comment);
 
-        userActivityService.recordActivity(userId, CREATE_COMMENT);
+        userActivityService.recordActivity(userId, CREATE_COMMENT, savedComment.getId());
     }
 
     @Transactional(readOnly = true)
@@ -94,5 +94,6 @@ public class CommentService {
         }
 
         comment.softDelete();
+        userActivityService.revokeActivity(userId, CREATE_COMMENT, commentId);
     }
 }

--- a/src/main/java/com/eventitta/comment/service/CommentService.java
+++ b/src/main/java/com/eventitta/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.eventitta.comment.dto.query.CommentFlatDto;
 import com.eventitta.comment.dto.response.CommentWithChildrenDto;
 import com.eventitta.comment.exception.CommentException;
 import com.eventitta.comment.repository.CommentRepository;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.exception.PostException;
 import com.eventitta.post.repository.PostRepository;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 import static com.eventitta.auth.exception.AuthErrorCode.NOT_FOUND_USER_ID;
 import static com.eventitta.comment.exception.CommentErrorCode.NOT_FOUND_COMMENT_ID;
 import static com.eventitta.comment.exception.CommentErrorCode.NO_AUTHORITY_TO_MODIFY_COMMENT;
+import static com.eventitta.gamification.domain.ActivityType.CREATE_COMMENT;
 import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
 
 @Service
@@ -32,6 +34,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final UserActivityService userActivityService;
 
     public void writeComment(Long postId, Long userId, String content, Long parentCommentId) {
         Post post = postRepository.findById(postId)
@@ -53,6 +56,8 @@ public class CommentService {
             .build();
 
         commentRepository.save(comment);
+
+        userActivityService.recordActivity(userId, CREATE_COMMENT);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/eventitta/event/dto/response/EventDistanceDto.java
+++ b/src/main/java/com/eventitta/event/dto/response/EventDistanceDto.java
@@ -4,20 +4,24 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 
-public record EventDistanceDto(
-    Long id,
-    String title,
-    String place,
+public interface EventDistanceDto {
+    Long getId();
+
+    String getTitle();
+
+    String getPlace();
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-    LocalDateTime startTime,
+    LocalDateTime getStartTime();
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
-    LocalDateTime endTime,
+    LocalDateTime getEndTime();
 
-    String category,
-    Boolean isFree,
-    String homepageUrl,
-    Double distance
-) {
+    String getCategory();
+
+    Boolean getIsFree();
+
+    String getHomepageUrl();
+
+    Double getDistance();
 }

--- a/src/main/java/com/eventitta/gamification/domain/ActivityType.java
+++ b/src/main/java/com/eventitta/gamification/domain/ActivityType.java
@@ -1,0 +1,24 @@
+package com.eventitta.gamification.domain;
+
+public enum ActivityType {
+    CREATE_POST(10, "게시글 작성"),
+    CREATE_COMMENT(5, "댓글 작성"),
+    LIKE_POST(1, "게시글 좋아요"),
+    JOIN_MEETING(20, "모임 참여");
+
+    private final int points;
+    private final String description;
+
+    ActivityType(int points, String description) {
+        this.points = points;
+        this.description = description;
+    }
+
+    public int getPoints() {
+        return points;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/eventitta/gamification/domain/Badge.java
+++ b/src/main/java/com/eventitta/gamification/domain/Badge.java
@@ -1,0 +1,25 @@
+package com.eventitta.gamification.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "badges")
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    private String iconUrl;
+}

--- a/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
+++ b/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
@@ -1,0 +1,30 @@
+package com.eventitta.gamification.domain;
+
+public enum BadgeRule {
+    FIRST_POST(ActivityType.CREATE_POST, 1, "첫 게시글"),
+    COMMENTER(ActivityType.CREATE_COMMENT, 10, "열혈 댓글러"),
+    PRO_LIKER(ActivityType.LIKE_POST, 50, "프로 좋아요꾼"),
+    FIRST_MEETING(ActivityType.JOIN_MEETING, 1, "첫 모임 참가");
+
+    private final ActivityType activityType;
+    private final long threshold;
+    private final String badgeName;
+
+    BadgeRule(ActivityType activityType, long threshold, String badgeName) {
+        this.activityType = activityType;
+        this.threshold = threshold;
+        this.badgeName = badgeName;
+    }
+
+    public ActivityType getActivityType() {
+        return activityType;
+    }
+
+    public long getThreshold() {
+        return threshold;
+    }
+
+    public String getBadgeName() {
+        return badgeName;
+    }
+}

--- a/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
+++ b/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
@@ -1,5 +1,8 @@
 package com.eventitta.gamification.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum BadgeRule {
     FIRST_POST(ActivityType.CREATE_POST, 1, "첫 게시글"),
     COMMENTER(ActivityType.CREATE_COMMENT, 10, "열혈 댓글러"),
@@ -14,17 +17,5 @@ public enum BadgeRule {
         this.activityType = activityType;
         this.threshold = threshold;
         this.badgeName = badgeName;
-    }
-
-    public ActivityType getActivityType() {
-        return activityType;
-    }
-
-    public long getThreshold() {
-        return threshold;
-    }
-
-    public String getBadgeName() {
-        return badgeName;
     }
 }

--- a/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
+++ b/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
@@ -1,21 +1,28 @@
 package com.eventitta.gamification.domain;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
-public enum BadgeRule {
-    FIRST_POST(ActivityType.CREATE_POST, 1, "첫 게시글"),
-    COMMENTER(ActivityType.CREATE_COMMENT, 10, "열혈 댓글러"),
-    PRO_LIKER(ActivityType.LIKE_POST, 50, "프로 좋아요꾼"),
-    FIRST_MEETING(ActivityType.JOIN_MEETING, 1, "첫 모임 참가");
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "badge_rules")
+public class BadgeRule {
 
-    private final ActivityType activityType;
-    private final long threshold;
-    private final String badgeName;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    BadgeRule(ActivityType activityType, long threshold, String badgeName) {
-        this.activityType = activityType;
-        this.threshold = threshold;
-        this.badgeName = badgeName;
-    }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ActivityType activityType;
+
+    @Column(nullable = false)
+    private long threshold;
 }

--- a/src/main/java/com/eventitta/gamification/domain/UserActivity.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserActivity.java
@@ -32,13 +32,17 @@ public class UserActivity {
     @Column(nullable = false)
     private int pointsEarned;
 
+    @Column(nullable = false)
+    private Long targetId;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    public UserActivity(User user, ActivityType activityType) {
+    public UserActivity(User user, ActivityType activityType, Long targetId) {
         this.user = user;
         this.activityType = activityType;
         this.pointsEarned = activityType.getPoints();
+        this.targetId = targetId;
     }
 }

--- a/src/main/java/com/eventitta/gamification/domain/UserActivity.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserActivity.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "user_activities")
+@Table(
+    name = "user_activities",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "activity_type", "target_id"})
+)
 public class UserActivity {
 
     @Id

--- a/src/main/java/com/eventitta/gamification/domain/UserActivity.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserActivity.java
@@ -1,0 +1,44 @@
+package com.eventitta.gamification.domain;
+
+import com.eventitta.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "user_activities")
+public class UserActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ActivityType activityType;
+
+    @Column(nullable = false)
+    private int pointsEarned;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    public UserActivity(User user, ActivityType activityType) {
+        this.user = user;
+        this.activityType = activityType;
+        this.pointsEarned = activityType.getPoints();
+    }
+}

--- a/src/main/java/com/eventitta/gamification/domain/UserBadge.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserBadge.java
@@ -1,0 +1,40 @@
+package com.eventitta.gamification.domain;
+
+import com.eventitta.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "user_badges")
+public class UserBadge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    public UserBadge(User user, Badge badge) {
+        this.user = user;
+        this.badge = badge;
+    }
+}

--- a/src/main/java/com/eventitta/gamification/domain/UserBadge.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserBadge.java
@@ -14,7 +14,8 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "user_badges")
+@Table(name = "user_badges",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "badge_id"}))
 public class UserBadge {
 
     @Id

--- a/src/main/java/com/eventitta/gamification/dto/query/ActivitySummary.java
+++ b/src/main/java/com/eventitta/gamification/dto/query/ActivitySummary.java
@@ -1,0 +1,9 @@
+package com.eventitta.gamification.dto.query;
+
+import com.eventitta.gamification.domain.ActivityType;
+
+public interface ActivitySummary {
+    ActivityType getActivityType();
+
+    long getCount();
+}

--- a/src/main/java/com/eventitta/gamification/dto/response/ActivitySummaryResponse.java
+++ b/src/main/java/com/eventitta/gamification/dto/response/ActivitySummaryResponse.java
@@ -1,0 +1,10 @@
+package com.eventitta.gamification.dto.response;
+
+public record ActivitySummaryResponse(
+    String activityType,
+    long count
+) {
+    public static ActivitySummaryResponse from(String activityType, long count) {
+        return new ActivitySummaryResponse(activityType, count);
+    }
+}

--- a/src/main/java/com/eventitta/gamification/repository/BadgeRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/BadgeRepository.java
@@ -1,0 +1,10 @@
+package com.eventitta.gamification.repository;
+
+import com.eventitta.gamification.domain.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+    Optional<Badge> findByName(String name);
+}

--- a/src/main/java/com/eventitta/gamification/repository/BadgeRuleRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/BadgeRuleRepository.java
@@ -1,0 +1,11 @@
+package com.eventitta.gamification.repository;
+
+import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.BadgeRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BadgeRuleRepository extends JpaRepository<BadgeRule, Long> {
+    List<BadgeRule> findByActivityType(ActivityType activityType);
+}

--- a/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
@@ -4,6 +4,10 @@ import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.domain.UserActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
     long countByUserIdAndActivityType(Long userId, ActivityType activityType);
+
+    Optional<UserActivity> findByUserIdAndActivityTypeAndTargetId(Long userId, ActivityType activityType, Long targetId);
 }

--- a/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
@@ -2,12 +2,22 @@ package com.eventitta.gamification.repository;
 
 import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.domain.UserActivity;
+import com.eventitta.gamification.dto.query.ActivitySummary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
     long countByUserIdAndActivityType(Long userId, ActivityType activityType);
 
     Optional<UserActivity> findByUserIdAndActivityTypeAndTargetId(Long userId, ActivityType activityType, Long targetId);
+
+    @Query("SELECT ua.activityType AS activityType, COUNT(ua) AS count " +
+        "FROM UserActivity ua " +
+        "WHERE ua.user.id = :userId " +
+        "GROUP BY ua.activityType")
+    List<ActivitySummary> countActivitiesByUser(@Param("userId") Long userId);
 }

--- a/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
@@ -1,0 +1,9 @@
+package com.eventitta.gamification.repository;
+
+import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.UserActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
+    long countByUserIdAndActivityType(Long userId, ActivityType activityType);
+}

--- a/src/main/java/com/eventitta/gamification/repository/UserBadgeRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserBadgeRepository.java
@@ -1,0 +1,8 @@
+package com.eventitta.gamification.repository;
+
+import com.eventitta.gamification.domain.UserBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+    boolean existsByUserIdAndBadgeId(Long userId, Long badgeId);
+}

--- a/src/main/java/com/eventitta/gamification/service/BadgeService.java
+++ b/src/main/java/com/eventitta/gamification/service/BadgeService.java
@@ -1,6 +1,7 @@
 package com.eventitta.gamification.service;
 
 import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.BadgeRule;
 import com.eventitta.gamification.domain.UserBadge;
 import com.eventitta.gamification.repository.BadgeRepository;
 import com.eventitta.gamification.repository.UserActivityRepository;
@@ -20,35 +21,13 @@ public class BadgeService {
 
     @Transactional
     public void checkAndAwardBadges(User user, ActivityType activityType) {
-        // 1: 첫 게시글 작성 배지
-        if (activityType == ActivityType.CREATE_POST) {
-            long postCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.CREATE_POST);
-            if (postCount == 1) {
-                awardBadge(user, "첫 게시글");
+        for (BadgeRule rule : BadgeRule.values()) {
+            if (rule.getActivityType() != activityType) {
+                continue;
             }
-        }
-
-        // 2: 댓글 10개 작성 배지
-        if (activityType == ActivityType.CREATE_COMMENT) {
-            long commentCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.CREATE_COMMENT);
-            if (commentCount >= 10) {
-                awardBadge(user, "열혈 댓글러");
-            }
-        }
-
-        // 3: 좋아요 50회 달성 배지
-        if (activityType == ActivityType.LIKE_POST) {
-            long likeCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.LIKE_POST);
-            if (likeCount >= 50) {
-                awardBadge(user, "인기의 게시글");
-            }
-        }
-
-        // 4: 첫 모임 참가 배지
-        if (activityType == ActivityType.JOIN_MEETING) {
-            long meetingCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.JOIN_MEETING);
-            if (meetingCount == 1) {
-                awardBadge(user, "첫 모임 참가");
+            long count = userActivityRepository.countByUserIdAndActivityType(user.getId(), rule.getActivityType());
+            if (count >= rule.getThreshold()) {
+                awardBadge(user, rule.getBadgeName());
             }
         }
     }

--- a/src/main/java/com/eventitta/gamification/service/BadgeService.java
+++ b/src/main/java/com/eventitta/gamification/service/BadgeService.java
@@ -1,0 +1,64 @@
+package com.eventitta.gamification.service;
+
+import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.UserBadge;
+import com.eventitta.gamification.repository.BadgeRepository;
+import com.eventitta.gamification.repository.UserActivityRepository;
+import com.eventitta.gamification.repository.UserBadgeRepository;
+import com.eventitta.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final BadgeRepository badgeRepository;
+    private final UserBadgeRepository userBadgeRepository;
+    private final UserActivityRepository userActivityRepository;
+
+    @Transactional
+    public void checkAndAwardBadges(User user, ActivityType activityType) {
+        // 1: 첫 게시글 작성 배지
+        if (activityType == ActivityType.CREATE_POST) {
+            long postCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.CREATE_POST);
+            if (postCount == 1) {
+                awardBadge(user, "첫 게시글");
+            }
+        }
+
+        // 2: 댓글 10개 작성 배지
+        if (activityType == ActivityType.CREATE_COMMENT) {
+            long commentCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.CREATE_COMMENT);
+            if (commentCount >= 10) {
+                awardBadge(user, "열혈 댓글러");
+            }
+        }
+
+        // 3: 좋아요 50회 달성 배지
+        if (activityType == ActivityType.LIKE_POST) {
+            long likeCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.LIKE_POST);
+            if (likeCount >= 50) {
+                awardBadge(user, "인기의 게시글");
+            }
+        }
+
+        // 4: 첫 모임 참가 배지
+        if (activityType == ActivityType.JOIN_MEETING) {
+            long meetingCount = userActivityRepository.countByUserIdAndActivityType(user.getId(), ActivityType.JOIN_MEETING);
+            if (meetingCount == 1) {
+                awardBadge(user, "첫 모임 참가");
+            }
+        }
+    }
+
+    private void awardBadge(User user, String badgeName) {
+        badgeRepository.findByName(badgeName).ifPresent(badge -> {
+            boolean alreadyHasBadge = userBadgeRepository.existsByUserIdAndBadgeId(user.getId(), badge.getId());
+            if (!alreadyHasBadge) {
+                userBadgeRepository.save(new UserBadge(user, badge));
+            }
+        });
+    }
+}

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -1,0 +1,32 @@
+package com.eventitta.gamification.service;
+
+import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.UserActivity;
+import com.eventitta.gamification.repository.UserActivityRepository;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
+
+@Service
+@RequiredArgsConstructor
+public class UserActivityService {
+    private final UserActivityRepository userActivityRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void recordActivity(Long userId, ActivityType activityType) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(NOT_FOUND_USER_ID::defaultException);
+
+        // 1. 사용자 활동 내역 생성 및 저장
+        UserActivity activity = new UserActivity(user, activityType);
+        userActivityRepository.save(activity);
+
+        // 2. 사용자 포인트 업데이트
+        user.addPoints(activityType.getPoints());
+    }
+}

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -27,8 +27,12 @@ public class UserActivityService {
             .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
         // 1. 사용자 활동 내역 생성 및 저장
-        UserActivity activity = new UserActivity(user, activityType, targetId);
-        userActivityRepository.save(activity);
+        boolean exists = userActivityRepository
+            .findByUserIdAndActivityTypeAndTargetId(userId, activityType, targetId)
+            .isPresent();
+        if (exists) {
+            return;
+        }
 
         // 2. 사용자 포인트 업데이트
         user.addPoints(activityType.getPoints());

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -4,10 +4,13 @@ import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.domain.UserActivity;
 import com.eventitta.gamification.repository.UserActivityRepository;
 import com.eventitta.user.domain.User;
+import com.eventitta.user.exception.UserErrorCode;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 
@@ -19,12 +22,12 @@ public class UserActivityService {
     private final BadgeService badgeService;
 
     @Transactional
-    public void recordActivity(Long userId, ActivityType activityType) {
+    public void recordActivity(Long userId, ActivityType activityType, Long targetId) {
         User user = userRepository.findById(userId)
             .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
         // 1. 사용자 활동 내역 생성 및 저장
-        UserActivity activity = new UserActivity(user, activityType);
+        UserActivity activity = new UserActivity(user, activityType, targetId);
         userActivityRepository.save(activity);
 
         // 2. 사용자 포인트 업데이트
@@ -32,5 +35,19 @@ public class UserActivityService {
 
         // 3. 배지 획득 조건 검사
         badgeService.checkAndAwardBadges(user, activityType);
+    }
+
+    @Transactional
+    public void revokeActivity(Long userId, ActivityType activityType, Long targetId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
+
+        Optional<UserActivity> activityToRevoke = userActivityRepository
+            .findByUserIdAndActivityTypeAndTargetId(userId, activityType, targetId);
+
+        if (activityToRevoke.isPresent()) {
+            user.addPoints(-activityType.getPoints());
+            userActivityRepository.delete(activityToRevoke.get());
+        }
     }
 }

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -46,7 +46,7 @@ public class UserActivityService {
             .findByUserIdAndActivityTypeAndTargetId(userId, activityType, targetId);
 
         if (activityToRevoke.isPresent()) {
-            user.addPoints(-activityType.getPoints());
+            user.subtractPoints(activityType.getPoints());
             userActivityRepository.delete(activityToRevoke.get());
         }
     }

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -16,6 +16,7 @@ import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 public class UserActivityService {
     private final UserActivityRepository userActivityRepository;
     private final UserRepository userRepository;
+    private final BadgeService badgeService;
 
     @Transactional
     public void recordActivity(Long userId, ActivityType activityType) {
@@ -28,5 +29,8 @@ public class UserActivityService {
 
         // 2. 사용자 포인트 업데이트
         user.addPoints(activityType.getPoints());
+
+        // 3. 배지 획득 조건 검사
+        badgeService.checkAndAwardBadges(user, activityType);
     }
 }

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -22,7 +22,7 @@ public class UserActivityService {
     private final BadgeService badgeService;
 
     @Transactional
-    public void recordActivity(Long userId, ActivityType activityType, Long targetId) {
+    public Optional<String> recordActivity(Long userId, ActivityType activityType, Long targetId) {
         User user = userRepository.findById(userId)
             .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
@@ -31,14 +31,14 @@ public class UserActivityService {
             .findByUserIdAndActivityTypeAndTargetId(userId, activityType, targetId)
             .isPresent();
         if (exists) {
-            return;
+            return Optional.empty();
         }
 
         // 2. 사용자 포인트 업데이트
         user.addPoints(activityType.getPoints());
 
         // 3. 배지 획득 조건 검사
-        badgeService.checkAndAwardBadges(user, activityType);
+        return badgeService.checkAndAwardBadges(user, activityType);
     }
 
     @Transactional

--- a/src/main/java/com/eventitta/meeting/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/eventitta/meeting/dto/response/ParticipantResponse.java
@@ -3,6 +3,8 @@ package com.eventitta.meeting.dto.response;
 import com.eventitta.meeting.domain.ParticipantStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "모임 참여자 정보")
 public record ParticipantResponse(
     @Schema(description = "참여자 ID", example = "1")

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -1,6 +1,7 @@
 package com.eventitta.meeting.service;
 
 import com.eventitta.common.response.PageResponse;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.meeting.domain.Meeting;
 import com.eventitta.meeting.domain.MeetingParticipant;
 import com.eventitta.meeting.domain.MeetingStatus;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.eventitta.gamification.domain.ActivityType.JOIN_MEETING;
 import static com.eventitta.meeting.exception.MeetingErrorCode.*;
 import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 
@@ -40,6 +42,7 @@ public class MeetingService {
     private final MeetingParticipantRepository participantRepository;
     private final MeetingMapper meetingMapper;
     private final UserRepository userRepository;
+    private final UserActivityService userActivityService;
 
     @Transactional
     public Long createMeeting(Long userId, MeetingCreateRequest request) {
@@ -165,6 +168,8 @@ public class MeetingService {
 
         participant.approve();
         meeting.incrementCurrentMembers();
+
+        userActivityService.recordActivity(participant.getUser().getId(), JOIN_MEETING);
 
         return meetingMapper.toParticipantResponse(participant, participant.getUser());
     }

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -169,6 +169,8 @@ public class MeetingService {
         participant.approve();
         meeting.incrementCurrentMembers();
 
+        userActivityService.recordActivity(participant.getUser().getId(), JOIN_MEETING, meetingId);
+
         return meetingMapper.toParticipantResponse(participant, participant.getUser());
     }
 

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -169,8 +169,6 @@ public class MeetingService {
         participant.approve();
         meeting.incrementCurrentMembers();
 
-        userActivityService.recordActivity(participant.getUser().getId(), JOIN_MEETING, meetingId);
-
         return meetingMapper.toParticipantResponse(participant, participant.getUser());
     }
 

--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -42,10 +42,10 @@ public class PostController {
         @CurrentUser Long userId,
         @Valid @RequestBody CreatePostRequest request
     ) {
-        Long id = postService.create(userId, request);
+        CreatePostResponse response = postService.create(userId, request);
         return ResponseEntity
-            .created(URI.create("/api/v1/posts/" + id))
-            .body(new CreatePostResponse(id));
+            .created(URI.create("/api/v1/posts/" + response.id()))
+            .body(response);
     }
 
     @Operation(summary = "게시글 목록 조회")

--- a/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
+++ b/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "게시글 생성 응답")
 public record CreatePostResponse(
     @Schema(description = "생성된 게시글의 ID", example = "123")
-    Long id
+    Long id,
+    @Schema(description = "획득한 배지명", example = "첫 게시글")
+    String badgeName
 ) {
 }

--- a/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
+++ b/src/main/java/com/eventitta/post/dto/response/CreatePostResponse.java
@@ -2,11 +2,13 @@ package com.eventitta.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "게시글 생성 응답")
 public record CreatePostResponse(
     @Schema(description = "생성된 게시글의 ID", example = "123")
     Long id,
     @Schema(description = "획득한 배지명", example = "첫 게시글")
-    String badgeName
+    List<String> badgeNames
 ) {
 }

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.eventitta.auth.exception.AuthErrorCode;
 import com.eventitta.auth.exception.AuthException;
 import com.eventitta.comment.repository.CommentRepository;
 import com.eventitta.common.response.PageResponse;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.domain.PostImage;
 import com.eventitta.post.domain.PostLike;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.eventitta.gamification.domain.ActivityType.CREATE_POST;
 import static com.eventitta.post.exception.PostErrorCode.ACCESS_DENIED;
 import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
 import static com.eventitta.region.exception.RegionErrorCode.NOT_FOUND_REGION_CODE;
@@ -45,6 +47,7 @@ public class PostService {
     private final RegionRepository regionRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
+    private final UserActivityService userActivityService;
 
 
     public Long create(Long userId, CreatePostRequest dto) {
@@ -59,7 +62,9 @@ public class PostService {
                 post.addImage(new PostImage(dto.imageUrls().get(i), i));
             }
         }
-        return postRepository.save(post).getId();
+        Post savedPost = postRepository.save(post);
+        userActivityService.recordActivity(userId, CREATE_POST);
+        return savedPost.getId();
     }
 
     public void update(Long postId, Long userId, UpdatePostRequest dto) {

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.eventitta.gamification.domain.ActivityType.CREATE_POST;
+import static com.eventitta.gamification.domain.ActivityType.LIKE_POST;
 import static com.eventitta.post.exception.PostErrorCode.ACCESS_DENIED;
 import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
 import static com.eventitta.region.exception.RegionErrorCode.NOT_FOUND_REGION_CODE;
@@ -137,6 +138,7 @@ public class PostService {
             PostLike like = new PostLike(post, user);
             postLikeRepository.save(like);
             post.incrementLikeCount();
+            userActivityService.recordActivity(userId, LIKE_POST);
         }
     }
 

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -64,7 +64,7 @@ public class PostService {
             }
         }
         Post savedPost = postRepository.save(post);
-        userActivityService.recordActivity(userId, CREATE_POST);
+        userActivityService.recordActivity(userId, CREATE_POST, savedPost.getId());
         return savedPost.getId();
     }
 
@@ -97,6 +97,7 @@ public class PostService {
         }
         post.clearImages();
         post.softDelete();
+        userActivityService.revokeActivity(userId, CREATE_POST, postId);
     }
 
     @Transactional(readOnly = true)
@@ -138,7 +139,7 @@ public class PostService {
             PostLike like = new PostLike(post, user);
             postLikeRepository.save(like);
             post.incrementLikeCount();
-            userActivityService.recordActivity(userId, LIKE_POST);
+            userActivityService.recordActivity(userId, LIKE_POST, postId);
         }
     }
 

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.eventitta.user.controller;
 
 import com.eventitta.auth.annotation.CurrentUser;
 import com.eventitta.common.response.ApiErrorResponse;
+import com.eventitta.gamification.dto.response.ActivitySummaryResponse;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
 import com.eventitta.user.dto.UserProfileResponse;
@@ -17,12 +19,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "사용자 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
 public class UserController {
     private final UserService userService;
+    private final UserActivityService userActivityService;
 
     @Operation(summary = "내 프로필 조회", description = "인증된 사용자의 프로필 정보를 조회합니다.")
     @ApiResponses({
@@ -75,5 +80,13 @@ public class UserController {
     ) {
         userService.changePassword(userId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me/activities")
+    public ResponseEntity<List<ActivitySummaryResponse>> getMyActivitySummary(@CurrentUser Long userId) {
+        List<ActivitySummaryResponse> result = userActivityService.getActivitySummary(userId).stream()
+            .map(summary -> new ActivitySummaryResponse(summary.getActivityType().toString(), summary.getCount()))
+            .toList();
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -1,6 +1,8 @@
 package com.eventitta.user.domain;
 
 import com.eventitta.common.config.BaseEntity;
+import com.eventitta.gamification.domain.UserActivity;
+import com.eventitta.gamification.domain.UserBadge;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -13,6 +15,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -75,6 +78,15 @@ public class User extends BaseEntity {
     private String providerId;
 
     @Column(nullable = false)
+    private int points = 0;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserActivity> activities = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserBadge> userBadges = new ArrayList<>();
+
+    @Column(nullable = false)
     @Builder.Default
     private boolean deleted = false;
 
@@ -102,5 +114,9 @@ public class User extends BaseEntity {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public void addPoints(int points) {
+        this.points += points;
     }
 }

--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -119,4 +119,8 @@ public class User extends BaseEntity {
     public void addPoints(int points) {
         this.points += points;
     }
+
+    public void subtractPoints(int amount) {
+        this.points = Math.max(0, this.points - amount);
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -22,3 +22,13 @@ VALUES ('1100000000', '서울특별시', NULL, 1),
        ('2801000000', '대구광역시 중구', '2800000000', 2),
        ('2801010100', '대구광역시 중구 동성로1가', '2801000000', 3),
        ('2900000000', '인천광역시', NULL, 1);
+
+INSERT INTO badges (id, name, description, icon_url)
+VALUES (1, '첫 게시글', '첫 번째 게시글을 작성하여 커뮤니티 활동을 시작했습니다.', 'https://eventitta.com/icons/first_post.png'),
+       (2, '열혈 댓글러', '댓글을 10개 이상 작성하여 활발하게 소통했습니다.', 'https://eventitta.com/icons/commenter.png'),
+       (3, '첫 모임 참가', '첫 번째 모임에 참가하여 새로운 인연을 만들었습니다.', 'https://eventitta.com/icons/first_meeting.png'),
+       (4, '프로 좋아요꾼', '다른 사람의 게시글에 좋아요를 50회 이상 눌렀습니다.', 'https://eventitta.com/icons/pro_liker.png')
+ON DUPLICATE KEY UPDATE name        = VALUES(name),
+                        description = VALUES(description),
+                        icon_url    = VALUES(icon_url);
+

--- a/src/test/java/com/eventitta/ControllerTestSupport.java
+++ b/src/test/java/com/eventitta/ControllerTestSupport.java
@@ -9,6 +9,7 @@ import com.eventitta.common.config.CustomAuthenticationEntryPoint;
 import com.eventitta.common.config.SecurityConfig;
 import com.eventitta.common.storage.FileStorageService;
 import com.eventitta.file.controller.FileUploadController;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.post.controller.PostController;
 import com.eventitta.post.service.PostService;
 import com.eventitta.user.controller.UserController;
@@ -57,4 +58,6 @@ public abstract class ControllerTestSupport {
     protected CommentService commentService;
     @MockitoBean
     protected UserService userService;
+    @MockitoBean
+    protected UserActivityService userActivityService;
 }

--- a/src/test/java/com/eventitta/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/eventitta/comment/controller/CommentControllerTest.java
@@ -30,7 +30,8 @@ class CommentControllerTest extends ControllerTestSupport {
     void createComment_withValidInput_returnsCreated() throws Exception {
         // given
         CommentRequestDto request = new CommentRequestDto("댓글 내용입니다.", null);
-        doNothing().when(commentService).writeComment(postId, userId, request.content(), request.parentCommentId());
+        given(commentService.writeComment(postId, userId, request.content(), request.parentCommentId()))
+            .willReturn(List.of("첫 댓글 작성 성공"));
 
         // when & then
         mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)

--- a/src/test/java/com/eventitta/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/eventitta/comment/service/CommentServiceTest.java
@@ -60,11 +60,12 @@ class CommentServiceTest {
 
         given(postRepository.findById(postId)).willReturn(Optional.of(post));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        willDoNothing().given(userActivityService).recordActivity(
+        given(userActivityService.recordActivity(
             eq(userId),
             eq(CREATE_COMMENT),
             anyLong()
-        );
+        )).willReturn(Optional.empty());
+
 
         long fakeCommentId = 123L;
         given(commentRepository.save(any(Comment.class)))

--- a/src/test/java/com/eventitta/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/eventitta/comment/service/CommentServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.eventitta.comment.exception.CommentErrorCode.NO_AUTHORITY_TO_MODIFY_COMMENT;
@@ -64,7 +65,7 @@ class CommentServiceTest {
             eq(userId),
             eq(CREATE_COMMENT),
             anyLong()
-        )).willReturn(Optional.empty());
+        )).willReturn(List.of());
 
 
         long fakeCommentId = 123L;

--- a/src/test/java/com/eventitta/gamification/repository/UserBadgeRepositoryTest.java
+++ b/src/test/java/com/eventitta/gamification/repository/UserBadgeRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.eventitta.gamification.repository;
+
+import com.eventitta.common.config.QuerydslConfig;
+import com.eventitta.gamification.domain.Badge;
+import com.eventitta.gamification.domain.UserBadge;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EntityScan(basePackages = "com.eventitta")
+class UserBadgeRepositoryTest {
+
+    @Autowired
+    UserBadgeRepository userBadgeRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    BadgeRepository badgeRepository;
+
+    @Test
+    @DisplayName("같은 배지를 두 번 발급하려 하면 예외가 발생한다")
+    void saveDuplicateUserBadge_throwsException() {
+        User user = userRepository.save(
+            User.builder()
+                .email("dup@test.com")
+                .password("encoded123")
+                .nickname("nick")
+                .role(Role.USER)
+                .provider(Provider.LOCAL)
+                .build()
+        );
+
+        Badge badge;
+        try {
+            var ctor = Badge.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            badge = ctor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        ReflectionTestUtils.setField(badge, "name", "test-badge");
+        ReflectionTestUtils.setField(badge, "description", "desc");
+        Badge savedBadge = badgeRepository.save(badge);
+
+        userBadgeRepository.saveAndFlush(new UserBadge(user, savedBadge));
+
+        assertThatThrownBy(() ->
+            userBadgeRepository.saveAndFlush(new UserBadge(user, savedBadge))
+        ).isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/eventitta/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/eventitta/meeting/controller/MeetingControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -92,7 +93,9 @@ class MeetingControllerTest {
     @WithMockCustomUser
     @DisplayName("참가 신청 승인 시 200을 반환한다")
     void approveParticipant_returnsOk() throws Exception {
-        ParticipantResponse resp = new ParticipantResponse(1L, 2L, "nick", null, ParticipantStatus.APPROVED);
+        ParticipantResponse resp = new ParticipantResponse(
+            10L, 42L, "스프링러버", "https://example.com/profile.jpg",
+            ParticipantStatus.APPROVED);
         given(meetingService.approveParticipant(42L, 1L, 10L)).willReturn(resp);
 
         mockMvc.perform(put("/api/v1/meetings/1/participants/10/approve"))

--- a/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
@@ -1,5 +1,6 @@
 package com.eventitta.meeting.service;
 
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.meeting.domain.Meeting;
 import com.eventitta.meeting.domain.MeetingParticipant;
 import com.eventitta.meeting.domain.MeetingStatus;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,9 +45,12 @@ class MeetingServiceTest {
     MeetingMapper meetingMapper;
     @Mock
     UserRepository userRepository;
+    @Mock
+    UserActivityService userActivityService;
 
     @InjectMocks
     MeetingService meetingService;
+
 
     private User createUser(Long id) {
         return User.builder()
@@ -208,6 +213,8 @@ class MeetingServiceTest {
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByIdWithMeeting(participantId)).willReturn(Optional.of(participant));
         given(meetingMapper.toParticipantResponse(any(), any())).willReturn(new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED));
+        given(meetingMapper.toParticipantResponse(any(), any())).willReturn(new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED));
+
 
         // when
         meetingService.approveParticipant(leaderId, meetingId, participantId);
@@ -283,6 +290,7 @@ class MeetingServiceTest {
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByMeetingIdAndUser_Id(meetingId, userId))
             .willReturn(Optional.of(participant));
+        willDoNothing().given(userActivityService).revokeActivity(any(), any(), any());
 
         // when
         meetingService.cancelJoin(userId, meetingId);

--- a/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
@@ -212,12 +212,11 @@ class MeetingServiceTest {
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByIdWithMeeting(participantId)).willReturn(Optional.of(participant));
-        given(meetingMapper.toParticipantResponse(any(), any())).willReturn(new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED));
-        given(meetingMapper.toParticipantResponse(any(), any())).willReturn(new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED));
-
-
+        given(meetingMapper.toParticipantResponse(any(), any())).willReturn(
+            new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED)
+        );
         // when
-        meetingService.approveParticipant(leaderId, meetingId, participantId);
+        ParticipantResponse response = meetingService.approveParticipant(leaderId, meetingId, participantId);
 
         // then
         assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.APPROVED);
@@ -253,7 +252,6 @@ class MeetingServiceTest {
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByIdWithMeeting(participantId)).willReturn(Optional.of(participant));
-        given(meetingMapper.toParticipantResponse(any(), any())).willReturn(new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.REJECTED));
 
         // when
         meetingService.rejectParticipant(leaderId, meetingId, participantId);

--- a/src/test/java/com/eventitta/post/controller/PostControllerTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerTest.java
@@ -7,8 +7,9 @@ import com.eventitta.common.response.PageResponse;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.request.CreatePostRequest;
-import com.eventitta.post.dto.response.PostDetailDto;
 import com.eventitta.post.dto.request.UpdatePostRequest;
+import com.eventitta.post.dto.response.CreatePostResponse;
+import com.eventitta.post.dto.response.PostDetailDto;
 import com.eventitta.post.dto.response.PostSummaryDto;
 import com.eventitta.post.exception.PostErrorCode;
 import com.eventitta.post.exception.PostException;
@@ -17,7 +18,6 @@ import com.eventitta.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -44,7 +44,7 @@ class PostControllerTest extends ControllerTestSupport {
         CreatePostRequest req = new CreatePostRequest("제목", "내용", "1100110100", List.of());
 
         given(postService.create(eq(42L), any(CreatePostRequest.class)))
-            .willReturn(fakePostId);
+            .willReturn(new CreatePostResponse(fakePostId, null));
 
         // when & then
         mockMvc.perform(post("/api/v1/posts")

--- a/src/test/java/com/eventitta/post/service/PostServiceTest.java
+++ b/src/test/java/com/eventitta/post/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.eventitta.post.service;
 
 import com.eventitta.auth.exception.AuthException;
 import com.eventitta.comment.repository.CommentRepository;
+import com.eventitta.gamification.service.UserActivityService;
 import com.eventitta.post.domain.PostLike;
 import com.eventitta.post.repository.PostLikeRepository;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -38,11 +39,13 @@ import org.springframework.data.domain.*;
 import java.util.List;
 import java.util.Optional;
 
+import static com.eventitta.gamification.domain.ActivityType.CREATE_POST;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 @DisplayName("동네 기반 게시글 단위 테스트")
@@ -59,6 +62,8 @@ class PostServiceTest {
     PostLikeRepository postLikeRepository;
     @Mock
     CommentRepository commentRepository;
+    @Mock
+    UserActivityService userActivityService;
 
     @InjectMocks
     PostService postService;
@@ -78,7 +83,8 @@ class PostServiceTest {
         Region region = createRegion(regionCode);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(regionRepository.findById(regionCode)).willReturn(Optional.of(region));
-
+        willDoNothing().given(userActivityService).recordActivity(userId, CREATE_POST);
+        
         Post savedPost = createPost(123L, user, createPostRequest.title(), createPostRequest.content(), region);
         savedPost.addImage(new PostImage("url1", 0));
         savedPost.addImage(new PostImage("url2", 1));
@@ -89,7 +95,6 @@ class PostServiceTest {
 
         // then
         assertThat(resultId).isEqualTo(123L);
-        // Verify that two images are added to the returned Post
         assertThat(savedPost.getImages()).hasSize(2);
     }
 

--- a/src/test/java/com/eventitta/post/service/PostServiceTest.java
+++ b/src/test/java/com/eventitta/post/service/PostServiceTest.java
@@ -83,8 +83,13 @@ class PostServiceTest {
         Region region = createRegion(regionCode);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(regionRepository.findById(regionCode)).willReturn(Optional.of(region));
-        willDoNothing().given(userActivityService).recordActivity(userId, CREATE_POST);
-        
+        willDoNothing()
+            .given(userActivityService)
+            .recordActivity(
+                eq(userId),
+                eq(CREATE_POST),
+                anyLong()
+            );
         Post savedPost = createPost(123L, user, createPostRequest.title(), createPostRequest.content(), region);
         savedPost.addImage(new PostImage("url1", 0));
         savedPost.addImage(new PostImage("url2", 1));
@@ -407,6 +412,15 @@ class PostServiceTest {
         Region region = createRegion(regionCode);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(regionRepository.findById(regionCode)).willReturn(Optional.of(region));
+
+        willDoNothing()
+            .given(userActivityService)
+            .recordActivity(
+                eq(userId),
+                eq(CREATE_POST),
+                any()
+            );
+
         final Post[] createdPostHolder = new Post[1];
         given(postRepository.save(any())).willAnswer(invocation -> {
             Post post = invocation.getArgument(0);


### PR DESCRIPTION
## 🔍 해결하려는 문제가 무엇인가요?
* 사용자의 커뮤니티 활동(댓글 작성·삭제, 모임 생성·참여 등)에 따른 포인트 적립 및 차감 기능이 없어서, 사용자 참여 유도와 리텐션 강화에 한계가 있었습니다.
* 활동 이력에 따른 뱃지(업적) 부여 로직이 없어, 특정 활동 달성 시 보상을 시각적으로 제공할 방법이 없었습니다.

## 🛠️ 어떻게 해결했나요?
* `gamification` 모듈을 새로 추가하여 활동 타입·포인트·뱃지·활동 이력 관리용 도메인(엔티티, 리포지토리, 서비스)을 구현했습니다.
* `UserActivityService.recordActivity`/`revokeActivity` 로직을 통해 활동 기록 시 포인트를 적립·차감하고, `BadgeService` 로직으로 뱃지 지급 조건을 검증 및 적용하도록 통합했습니다.
* 기존 `CommentService`, `MeetingService` 에서 댓글 작성·삭제, 모임 생성·참여 시 해당 서비스들을 호출하도록 변경하여 자동으로 활동을 기록하고 포인트/뱃지를 부여하도록 연동했습니다.
* DTO, 서비스 인터페이스를 확장해 적립된 포인트와 새로 획득한 뱃지 목록을 API 응답에 포함시켰습니다.

## ✨ 주요 변경사항
* **도메인 추가**  
  - `ActivityType` enum: 활동 종류별 기본 점수 및 설명 정의  
  - `UserActivity` 엔티티·리포지토리: 사용자 활동 이력 로그 테이블  
  - `Badge`·`BadgeRule` 엔티티·리포지토리: 뱃지, 지급 조건(활동 수치 임계치) 관리  
* **서비스 로직**  
  - `UserActivityService` : 활동 기록·취소, 포인트 합산, 뱃지 지급 트리거 구현  
  - `BadgeService` : 규칙별 뱃지 지급 검증 및 사용자 뱃지 이력 관리  
* **통합 연동**  
  - `CommentService.writeComment`/`deleteComment` 에서 `recordActivity`/`revokeActivity` 호출  
  - `MeetingService.joinMeeting` 등 참여 메서드에서 활동 기록 호출  
* **API 응답 확장**  
  - 댓글 작성·모임 생성 등의 결과 DTO에 `awardedPoints`, `awardedBadges` 필드 추가

## ✅ 검증 시나리오
1. **댓글 작성**  
   - 정상 요청 시 `COMMENT_CREATE`(+5점) 포인트 적립 확인  
   - 누적 댓글 수에 따라 “첫 댓글 작성”, “댓글 10회 달성” 뱃지 지급 여부 확인  
2. **댓글 삭제**  
   - 삭제 시 `revokeActivity` 호출로 포인트 차감 및 뱃지 취소(조건 미달 시) 확인  
3. **모임 생성·참여**  
   - 모임 생성 시 `MEETING_CREATE`(+15점) 포인트 적립, “첫 모임 생성” 뱃지 지급 확인  
   - 모임 참여 신청/취소 시 `recordActivity`/`revokeActivity` 로 포인트 변화 확인  
4. **뱃지 지급 로직**  
   - `BadgeRule` 조건(활동 타입별 임계치)에 맞춰 뱃지가 중복 지급되지 않고, 취소 후 재지급도 정상 동작하는지 확인  
5. **일반 기능 회귀**  
   - 기존 댓글 작성/삭제, 모임 CRUD API 동작 정상 여부 및 기존 응답 스펙 유지 확인  

## ⚙️ 머지 전 체크
- [ ] 코드 스타일/포맷팅 확인  
- [ ] 변경 라인 수 300줄 이내 유지  

## 📎 첨부 (Attachment)


## 📚 참고 링크

