### PR TITLE
test-유저활동 뱃지 지급

### DIFF
--- a/src/main/java/com/eventitta/common/filter/ResponseTimeFilter.java
+++ b/src/main/java/com/eventitta/common/filter/ResponseTimeFilter.java
@@ -1,0 +1,23 @@
+package com.eventitta.common.filter;
+
+import jakarta.servlet.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class ResponseTimeFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        long start = System.currentTimeMillis();
+
+        chain.doFilter(request, response);  // 컨트롤러 실행
+
+        long end = System.currentTimeMillis();
+        log.info("진짜 API 응답 시간: {}ms", end - start);
+    }
+}

--- a/src/main/java/com/eventitta/gamification/activitylog/ActivityEventPublisher.java
+++ b/src/main/java/com/eventitta/gamification/activitylog/ActivityEventPublisher.java
@@ -1,9 +1,11 @@
 package com.eventitta.gamification.activitylog;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ActivityEventPublisher {

--- a/src/main/java/com/eventitta/gamification/service/BadgeService.java
+++ b/src/main/java/com/eventitta/gamification/service/BadgeService.java
@@ -10,6 +10,7 @@ import com.eventitta.gamification.repository.UserBadgeRepository;
 import com.eventitta.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ public class BadgeService {
     private final UserBadgeRepository userBadgeRepository;
     private final List<BadgeRuleEvaluator> evaluators;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<String> checkAndAwardBadges(User user, UserPoints userPoints) {
         List<BadgeRule> rules = badgeRuleRepository.findAll();
         List<String> awarded = new ArrayList<>();

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -23,6 +23,7 @@ import com.eventitta.region.repository.RegionRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +41,7 @@ import static com.eventitta.post.exception.PostErrorCode.NOT_FOUND_POST_ID;
 import static com.eventitta.region.exception.RegionErrorCode.NOT_FOUND_REGION_CODE;
 import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -66,7 +68,7 @@ public class PostService {
         Post savedPost = postRepository.save(post);
 
         activityEventPublisher.publish(CREATE_POST, userId, savedPost.getId());
-
+        
         return new CreatePostResponse(savedPost.getId());
     }
 
@@ -117,6 +119,7 @@ public class PostService {
         );
     }
 
+    // Autocommit
     @Transactional(readOnly = true)
     public PostDetailDto getPost(Long postId) {
         Post post = postRepository.findDetailByIdAndDeletedFalse(postId)

--- a/src/test/java/com/eventitta/gamification/activitylog/ActivityEventPublisherTest.java
+++ b/src/test/java/com/eventitta/gamification/activitylog/ActivityEventPublisherTest.java
@@ -1,0 +1,41 @@
+package com.eventitta.gamification.activitylog;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@DisplayName("사용자 활동 이벤트 퍼블리셔의 동작을 검증하는 테스트")
+class ActivityEventPublisherTest {
+
+    @Test
+    @DisplayName("활동 코드, 사용자 ID, 대상 ID를 전달하면 사용자 활동 로그 이벤트가 정상적으로 발행된다")
+    void givenCodeUserIdTargetId_whenPublish_thenUserActivityLogRequestedEventIsPublished() {
+        ApplicationEventPublisher mockPublisher = mock(ApplicationEventPublisher.class);
+        ActivityEventPublisher eventPublisher = new ActivityEventPublisher(mockPublisher);
+
+        eventPublisher.publish("CODE", 1L, 2L);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue())
+            .isInstanceOf(UserActivityLogRequestedEvent.class);
+    }
+
+    @Test
+    @DisplayName("활동 코드, 사용자 ID, 대상 ID를 전달하면 사용자 활동 취소 이벤트가 정상적으로 발행된다")
+    void givenCodeUserIdTargetId_whenPublishRevoke_thenUserActivityRevokeRequestedEventIsPublished() {
+        ApplicationEventPublisher mockPublisher = mock(ApplicationEventPublisher.class);
+        ActivityEventPublisher eventPublisher = new ActivityEventPublisher(mockPublisher);
+
+        eventPublisher.publishRevoke("CODE", 1L, 2L);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(mockPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue())
+            .isInstanceOf(UserActivityRevokeRequestedEvent.class);
+    }
+}

--- a/src/test/java/com/eventitta/gamification/activitylog/UserActivityEventListenerTest.java
+++ b/src/test/java/com/eventitta/gamification/activitylog/UserActivityEventListenerTest.java
@@ -10,13 +10,16 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -30,82 +33,168 @@ class UserActivityEventListenerTest {
     private ApplicationEventPublisher eventPublisher;
 
     @Autowired
-    private PlatformTransactionManager txManager;
+    private TransactionTemplate transactionTemplate;
 
-    @MockitoSpyBean
+    @MockitoBean
     private UserActivityService userActivityService;
 
     @Autowired
     private ApplicationContext applicationContext;
 
-
     @Test
-    @DisplayName("게시글 작성 요청 시 트랜잭션이 커밋되어야만 활동 로그가 남는다")
-    void givenLogEvent_whenCommitted_thenRecordActivityInvoked() {
+    @DisplayName("게시글 작성 시 활동 내역이 기록된다")
+    void givenLogEvent_whenPublished_thenRecordActivityInvoked() {
+        // given
         doNothing().when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
 
-        TransactionTemplate tx = new TransactionTemplate(txManager);
-        tx.executeWithoutResult(status -> {
+        // when - 트랜잭션 안에서 이벤트 발행
+        transactionTemplate.execute(status -> {
             eventPublisher.publishEvent(new UserActivityLogRequestedEvent(1L, ActivityCodes.CREATE_POST, 10L));
-            verify(userActivityService, never()).recordActivity(anyLong(), anyString(), anyLong());
-        });
+            return null;
+        }); // 여기서 커밋 발생 → AFTER_COMMIT 이벤트 실행
 
-        verify(userActivityService, timeout(1000).times(1))
+        // then
+        verify(userActivityService, timeout(2000).times(1))
             .recordActivity(1L, ActivityCodes.CREATE_POST, 10L);
     }
 
     @Test
-    @DisplayName("좋아요 취소 시 트랜잭션 커밋이 완료된 후 활동 로그가 삭제된다")
-    void givenRevokeEvent_whenCommitted_thenRevokeActivityInvoked() {
+    @DisplayName("좋아요 취소 시 활동 내역이 삭제된다")
+    void givenRevokeEvent_whenPublished_thenRevokeActivityInvoked() {
+        // given
         doNothing().when(userActivityService).revokeActivity(anyLong(), anyString(), anyLong());
 
-        TransactionTemplate tx = new TransactionTemplate(txManager);
-        tx.executeWithoutResult(status -> {
+        // when
+        transactionTemplate.execute(status -> {
             eventPublisher.publishEvent(new UserActivityRevokeRequestedEvent(2L, ActivityCodes.LIKE_POST, 20L));
-            verify(userActivityService, never()).revokeActivity(anyLong(), anyString(), anyLong());
+            return null;
         });
 
-        verify(userActivityService, timeout(1000).times(1))
+        // then
+        verify(userActivityService, timeout(2000).times(1))
             .revokeActivity(2L, ActivityCodes.LIKE_POST, 20L);
     }
 
     @Test
-    @DisplayName("트랜잭션 롤백 시 활동 로그가 남지 않는다")
-    void givenLogEvent_whenRollback_thenRecordActivityNotInvoked() throws InterruptedException {
-        doNothing().when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
-
-        TransactionTemplate tx = new TransactionTemplate(txManager);
-        tx.executeWithoutResult(status -> {
-            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(3L, ActivityCodes.CREATE_POST, 30L));
-            verify(userActivityService, never()).recordActivity(anyLong(), anyString(), anyLong());
-            status.setRollbackOnly();
-        });
-
-        verify(userActivityService, never()).recordActivity(anyLong(), anyString(), anyLong());
-    }
-
-    @Test
-    @DisplayName("이벤트 리스너는 별도 스레드에서 실행된다")
+    @DisplayName("이벤트 리스너가 별도의 스레드에서 동작한다")
     void givenEvent_whenHandled_thenRunsInDifferentThread() {
+        // given
         AtomicReference<String> listenerThread = new AtomicReference<>();
         doAnswer(invocation -> {
             listenerThread.set(Thread.currentThread().getName());
             return null;
         }).when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
 
-        AtomicReference<String> txThread = new AtomicReference<>();
-        TransactionTemplate tx = new TransactionTemplate(txManager);
-        tx.executeWithoutResult(status -> {
-            txThread.set(Thread.currentThread().getName());
+        String mainThread = Thread.currentThread().getName();
+
+        // when
+        transactionTemplate.execute(status -> {
             eventPublisher.publishEvent(new UserActivityLogRequestedEvent(3L, ActivityCodes.CREATE_POST, 30L));
+            return null;
         });
 
-        verify(userActivityService, timeout(1000).times(1)).recordActivity(3L, ActivityCodes.CREATE_POST, 30L);
+        // then
+        verify(userActivityService, timeout(2000).times(1))
+            .recordActivity(3L, ActivityCodes.CREATE_POST, 30L);
 
         assertThat(listenerThread.get()).isNotNull();
-        assertThat(txThread.get()).isNotNull();
-        assertThat(listenerThread.get()).isNotEqualTo(txThread.get());
+        assertThat(listenerThread.get()).isNotEqualTo(mainThread);
         assertThat(listenerThread.get()).startsWith("ActivityEvent-");
         assertThat(applicationContext.getBean(com.eventitta.common.config.AsyncConfig.class)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("활동 기록 중 오류가 발생하면 로그가 남는다")
+    void givenException_whenRecordActivity_thenErrorLogged() {
+        // given
+        AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            exceptionThrown.set(true);
+            throw new RuntimeException("에러 발생");
+        }).when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
+
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(4L, ActivityCodes.CREATE_POST, 40L));
+            return null;
+        });
+
+        // then
+        verify(userActivityService, timeout(2000).times(1))
+            .recordActivity(4L, ActivityCodes.CREATE_POST, 40L);
+
+        // 예외가 실제로 발생했는지 확인
+        assertThat(exceptionThrown.get()).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 이벤트 파라미터가 들어오면 예외가 발생하고 로그가 남는다")
+    void givenInvalidParameter_whenEventPublished_thenExceptionLoggedAndHandled() {
+        // given
+        doThrow(new IllegalArgumentException("Invalid activityCode"))
+            .when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
+
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(5L, null, 50L));
+            return null;
+        });
+
+        // then - 이벤트 리스너가 호출되었는지만 확인
+        verify(userActivityService, timeout(2000).times(1))
+            .recordActivity(5L, null, 50L);
+        // 로그로만 남고 시스템은 정상 동작함
+    }
+
+    @Test
+    @DisplayName("동일한 이벤트가 여러 번 발생해도 중복 기록되지 않는다")
+    void givenDuplicateEvent_whenPublished_thenNoDuplicateActivity() {
+        // given
+        doNothing().when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
+
+        // when - 동일한 이벤트를 두 번 발행
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(6L, ActivityCodes.CREATE_POST, 60L));
+            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(6L, ActivityCodes.CREATE_POST, 60L));
+            return null;
+        });
+
+        // then - 이벤트는 2번 발행되므로 리스너도 2번 호출됨
+        verify(userActivityService, timeout(2000).times(2))
+            .recordActivity(6L, ActivityCodes.CREATE_POST, 60L);
+        // 참고: 실제 중복 방지는 UserActivityService 내부 로직에서 처리됨
+    }
+
+    @Test
+    @DisplayName("비동기 작업이 지연되거나 실패해도 시스템이 정상 동작한다")
+    void givenAsyncFailureOrDelay_whenEventPublished_thenSystemHandlesGracefully() throws InterruptedException {
+        // given
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            try {
+                // 지연 시뮬레이션을 CountDownLatch로 대체
+                exceptionOccurred.set(true);
+                throw new RuntimeException("비동기 실패");
+            } finally {
+                latch.countDown(); // 완료 신호
+            }
+        }).when(userActivityService).recordActivity(anyLong(), anyString(), anyLong());
+
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new UserActivityLogRequestedEvent(7L, ActivityCodes.CREATE_POST, 70L));
+            return null;
+        });
+
+        // then - 최대 3초 대기, 완료되면 즉시 통과
+        assertTrue(latch.await(3, TimeUnit.SECONDS), "이벤트 처리가 완료되지 않았습니다");
+
+        verify(userActivityService, times(1))
+            .recordActivity(7L, ActivityCodes.CREATE_POST, 70L);
+
+        // 예외가 발생했지만 시스템은 정상 동작함을 확인
+        assertThat(exceptionOccurred.get()).isTrue();
     }
 }

--- a/src/test/java/com/eventitta/gamification/service/UserActivityServiceTest.java
+++ b/src/test/java/com/eventitta/gamification/service/UserActivityServiceTest.java
@@ -24,7 +24,8 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -147,7 +148,6 @@ class UserActivityServiceTest {
 
         // then
         assertThat(points.getPoints()).isEqualTo(15);
-        verify(userPointsRepository).save(points);
         verify(userActivityRepository).delete(activity);
     }
 }


### PR DESCRIPTION

<!--
  PR 템플릿
  - 작은 PR: 변경 라인 수 최대 300줄 이내 유지
  - Low-Context: 리뷰어가 따로 물어보지 않아도 이해할 수 있도록 충분한 설명
  - Attachment: ERD나 클래스 다이어그램 등 시각 자료 첨부
-->

## 🔍 해결하려는 문제가 무엇인가요?

- API 응답 시간 모니터링이 부족하여 성능 이슈 파악이 어려웠습니다.
- 트랜잭션 전파 설정으로 인해 배지 발급과 사용자 활동 기록 간 의존성 문제가 발생했습니다.
- 이벤트 발행 및 사용자 활동 서비스에 대한 테스트 커버리지가 부족했습니다.
- 불필요한 DB flush 호출과 중복 리포지토리 작업으로 성능 저하가 있었습니다.

## 🛠️ 어떻게 해결했나요?

- ResponseTimeFilter를 추가하여 모든 API 요청의 응답 시간을 로깅하도록 구현했습니다.
- BadgeService와 UserActivityService에 REQUIRES_NEW 전파 옵션을 적용하여 독립적인 트랜잭션으로 분리했습니다.
- 각 서비스 클래스에 @Slf4j를 추가하여 상세한 로깅 체계를 구축했습니다.
- TransactionTemplate 사용을 제거하고 선언적 트랜잭션으로 단순화했습니다

## ✨ 주요 변경사항

- ResponseTimeFilter 신규 추가: API 성능 모니터링을 위한 응답 시간 로깅
- 트랜잭션 관리 개선: REQUIRES_NEW 전파 옵션으로 독립적 트랜잭션 보장
- 로깅 체계 강화: ActivityEventPublisher, UserActivityService, PostService에 로깅 추가
- 메서드 접근성 개선: UserActivityService.performRecordActivity를 public으로 변경
- 테스트 커버리지 확장: ActivityEventPublisherTest 신규 추가, UserActivityEventListenerTest 시나리오 확장
- 코드 최적화: 불필요한 flush 호출 및 중복 리포지토리 작업 제거

## ✅ 검증 시나리오
- API 호출 시 응답 시간이 로그에 정상 출력되는지 확인
- 배지 발급 실패 시에도 사용자 활동 기록이 정상 저장되는지 테스트
- 이벤트 발행 시 중복 방지 및 비동기 처리가 올바르게 동작하는지 검증
- 기존 기능들이 정상 작동하는지 회귀 테스트 수행

## ⚙️ 머지 전 체크
- [ ] 코드 스타일/포맷팅 확인
- [ ] 변경 라인 수 300줄 이내 유지

## 📎 첨부 (Attachment)
### 사용자 활동 이벤트 및 배지 지급 트랜잭션 구조

```
사용자 활동 발생
      │
      ▼
[ActivityEventPublisher] ──▶ [UserActivityEventListener]
      │                          │
      │                          ▼
      │                 [UserActivityService]
      │                          │
      ▼                          ▼
  이벤트 저장                [BadgeService] ──▶ 배지 지급/트랜잭션 처리
```


## 📚 참고 링크
[Spring Events - Baeldung](https://www.baeldung.com/spring-events)
[Spring Boot Event Documentation](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#context-functionality-events)
[ThreadPoolTaskExecutor 공식 문서](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.html)
