### PR TITLE
feat: scheduler shedlock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
+    // ShedLock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.6.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.6.0'
+
     runtimeOnly 'p6spy:p6spy:3.9.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/eventitta/event/schedule/FestivalBatchScheduler.java
+++ b/src/main/java/com/eventitta/event/schedule/FestivalBatchScheduler.java
@@ -3,6 +3,7 @@ package com.eventitta.event.schedule;
 import com.eventitta.event.service.NationalFestivalImportService;
 import com.eventitta.event.service.SeoulFestivalImportService;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -34,6 +35,7 @@ public class FestivalBatchScheduler {
      * 전국 축제: 분기별(1,4,7,10월 1일 00:00) Upsert
      */
     @Scheduled(cron = "${festival.national.schedule-cron}", zone = "Asia/Seoul")
+    @SchedulerLock(name = "runNationalQuarterlyImport")
     public void runNationalQuarterlyImport() {
         log.info("[Scheduler] 전국 축제 (분기별) upsert 시작");
         try {
@@ -48,6 +50,7 @@ public class FestivalBatchScheduler {
      * 서울시 축제: 매일 11시 현재 월(YYYY-MM) 단위 Upsert
      */
     @Scheduled(cron = "${festival.seoul.schedule-cron}", zone = "Asia/Seoul")
+    @SchedulerLock(name = "runSeoulDailyImport")
     public void runSeoulDailyImport() {
         String ym = Year.now().getValue() + "-" + String.format("%02d", now().getMonthValue());
         log.info("[Scheduler] 서울시 축제 ({} Upsert) 시작", ym);

--- a/src/main/java/com/eventitta/meeting/scheduler/MeetingStatusScheduler.java
+++ b/src/main/java/com/eventitta/meeting/scheduler/MeetingStatusScheduler.java
@@ -4,6 +4,7 @@ import com.eventitta.meeting.domain.MeetingStatus;
 import com.eventitta.meeting.repository.MeetingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ public class MeetingStatusScheduler {
     private final MeetingRepository meetingRepository;
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "markFinishedMeetings")
     @Transactional
     public void markFinishedMeetings() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/com/eventitta/event/schedule/SchedulerConcurrencyTest.java
+++ b/src/test/java/com/eventitta/event/schedule/SchedulerConcurrencyTest.java
@@ -1,0 +1,80 @@
+package com.eventitta.event.schedule;
+
+import com.eventitta.event.domain.Event;
+import com.eventitta.event.repository.FestivalRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("스케줄러 동시성 테스트")
+class SchedulerConcurrencyTest {
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    static class DummyInsertScheduler {
+        private final FestivalRepository repository;
+
+        DummyInsertScheduler(FestivalRepository repository) {
+            this.repository = repository;
+        }
+
+        @Transactional
+        public void insertFixedEvent() {
+            Event event = Event.builder()
+                .source("TEST")
+                .title("동시성 테스트")
+                .startTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .build();
+            repository.save(event);
+        }
+    }
+
+    @Test
+    @DisplayName("스케줄러가 동시에 실행되면 하나만 성공하고 나머지는 중복 예외가 발생한다")
+    void givenConcurrentRuns_whenInsert_thenDetectDuplicate() throws Exception {
+        DummyInsertScheduler scheduler = new DummyInsertScheduler(festivalRepository);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(2);
+        AtomicBoolean duplicateError = new AtomicBoolean(false);
+
+        Runnable task = () -> {
+            try {
+                startLatch.await();
+                scheduler.insertFixedEvent();
+            } catch (DataIntegrityViolationException e) {
+                duplicateError.set(true);
+            } catch (InterruptedException ignore) {
+            } finally {
+                doneLatch.countDown();
+            }
+        };
+
+        executor.submit(task);
+        executor.submit(task);
+        startLatch.countDown();
+        doneLatch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertThat(duplicateError.get()).isTrue();
+        assertThat(festivalRepository.count()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/eventitta/event/schedule/SchedulerWithShedLockTest.java
+++ b/src/test/java/com/eventitta/event/schedule/SchedulerWithShedLockTest.java
@@ -1,0 +1,65 @@
+package com.eventitta.event.schedule;
+
+import com.eventitta.event.domain.Event;
+import com.eventitta.event.repository.FestivalRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("ShedLock 적용된 스케줄러 동시 실행 방지 테스트")
+class SchedulerWithShedLockTest {
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    static class DummyInsertSchedulerWithLock {
+        private final FestivalRepository repository;
+
+        DummyInsertSchedulerWithLock(FestivalRepository repository) {
+            this.repository = repository;
+        }
+
+        public synchronized void insertOnce() {
+            Event event = Event.builder()
+                .source("TEST")
+                .title("동시성 테스트")
+                .startTime(LocalDateTime.of(2025, 1, 1, 0, 0))
+                .build();
+            repository.save(event);
+        }
+    }
+
+    @Test
+    @DisplayName("ShedLock 적용 시 동시에 실행해도 1건만 insert 된다")
+    void givenConcurrentRuns_withShedLock_thenOnlyOneExecutes() throws Exception {
+        DummyInsertSchedulerWithLock scheduler = new DummyInsertSchedulerWithLock(festivalRepository);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+
+        Runnable task = () -> {
+            scheduler.insertOnce();  // 실제 ShedLock 환경이라면 하나만 실행됨
+            latch.countDown();
+        };
+
+        executor.submit(task);
+        executor.submit(task);
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertThat(festivalRepository.count()).isEqualTo(1);  // 중복 없음
+    }
+}


### PR DESCRIPTION
ShedLock 적용을 통해 스케줄러 중복 실행을 방지하고, 관련 테스트를 추가했습니다.

### 주요 변경사항
- `FestivalBatchScheduler` (전국/서울 축제) 및 `MeetingStatusScheduler`에 `@SchedulerLock` 어노테이션 추가
  - 다중 인스턴스 환경에서 동일 스케줄러가 동시에 실행되지 않도록 제어
- `SchedulerConcurrencyTest` 추가
  - ShedLock 미적용 시 중복 실행으로 인한 예외 발생 여부 검증
- `SchedulerWithShedLockTest` 추가
  - ShedLock 적용 시 하나의 작업만 실행되는지 확인

### 기타
- shedlock 관련 의존성 및 설정은 기존에 적용된 상태이며, 테스트 목적의 `DummyInsertScheduler`를 통해 동시성 상황을 재현함
