### PR TITLE
fix(user): User 엔티티 pk 자료형 변경

### DIFF
--- a/src/main/java/com/eventitta/user/domain/User.java
+++ b/src/main/java/com/eventitta/user/domain/User.java
@@ -30,7 +30,6 @@ public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(columnDefinition = "INT UNSIGNED")
     private Long id;
 
     @Email

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     defer-datasource-initialization: true
 
     properties:


### PR DESCRIPTION
변경 요약
	•	로컬 프로파일에서 JPA 스키마 전략을 update → create-drop으로 변경
	•	User 엔티티 id 필드의 @Column(columnDefinition = "INT UNSIGNED") 제거(기본 매핑 사용)

상세 변경

1) 환경설정 (application-local.yml)
	•	spring.jpa.hibernate.ddl-auto: create-drop
	•	로컬 실행마다 스키마를 새로 생성/삭제하여 DDL 일관성 확보 및 스키마 드리프트 방지

2) 엔티티 매핑 (User)
	•	id 컬럼의 명시적 columnDefinition 제거
	•	Dialect 기본 타입 매핑을 따르도록 단순화(불필요한 DB 벤더 종속 제거)

변경 의도/배경
	•	update 전략은 로컬에서 스키마가 점진적으로 누적·왜곡되어 팀원 간 환경 차이를 유발
	•	create-drop으로 고정하면 깨끗한 시작을 보장 → 이슈 재현성과 온보딩 속도 개선
	•	columnDefinition 제거로 테스트 DB(H2 등) 및 향후 벤더 전환 시 호환성 향상

영향 및 주의사항
	•	로컬 데이터는 매 실행마다 초기화됩니다. 필요한 경우 seed 스크립트/데이터 로더를 함께 사용하세요.
	•	INT UNSIGNED 제거로 정수 범위가 벤더 기본(대개 INT signed)으로 복귀
	•	id가 Integer라면 최대값은 2,147,483,647
	•	장기적으로 식별자 공간이 우려되면 Long/BIGINT 전환을 검토 권장
	•	변경은 로컬 프로파일에만 적용(운영/테스트 프로파일 영향 없음)

검증 방법
	1.	--spring.profiles.active=local로 서버 실행
	2.	시작 로그에서 테이블 재생성(Hibernate DDL) 확인
	3.	기본 흐름(회원 생성 → 조회) 점검
	4.	재기동 후 데이터가 초기화되는지 확인

롤백 계획
	•	application-local.yml의 ddl-auto를 update로 복구
	•	필요 시 User.id의 columnDefinition 복원