### PR TITLE
fix: application-docker.yml db insert 스크립트 실행 해제

### DIFF
--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -15,10 +15,8 @@ spring:
 
   sql:
     init:
-      mode: always
-      schema-locations: classpath:schema.sql
-      data-locations: classpath:data.sql
-
+      mode: never
+  
   devtools:
     restart:
       enabled: true


### PR DESCRIPTION
This pull request makes a small configuration change to the `application-docker.yml` file. The change disables the automatic initialization of the SQL schema and data when running in Docker.

* In `src/main/resources/application-docker.yml`, the `sql.init.mode` is set to `never`, and the `schema-locations` and `data-locations` properties are removed.