### PR TITLE
test: add rate limiter

### DIFF
--- a/src/test/java/com/eventitta/common/notification/resolver/AlertLevelResolverTest.java
+++ b/src/test/java/com/eventitta/common/notification/resolver/AlertLevelResolverTest.java
@@ -1,0 +1,202 @@
+package com.eventitta.common.notification.resolver;
+
+import com.eventitta.common.exception.CustomException;
+import com.eventitta.common.exception.ErrorCode;
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+
+import java.net.ConnectException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("시스템 오류 발생 시 알림 등급을 자동으로 결정하는 기능")
+class AlertLevelResolverTest {
+
+    private AlertLevelResolver alertLevelResolver;
+
+    @BeforeEach
+    void setUp() {
+        alertLevelResolver = new AlertLevelResolver();
+    }
+
+    @DisplayName("데이터베이스가 연결되지 않으면 'CRITICAL' 등급으로 분류한다")
+    @Test
+    void shouldResolveToCriticalForDataAccessException() {
+        // given
+        DataAccessException exception = new DataAccessException("연결 거부") {
+        };
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.CRITICAL);
+    }
+
+    @DisplayName("서버가 연결을 거부하면 '매우 위험' 등급으로 분류한다")
+    @Test
+    void shouldResolveToCriticalForConnectException() {
+        // given
+        ConnectException exception = new ConnectException("연결 거부");
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.CRITICAL);
+    }
+
+    @DisplayName("'연결 거부' 메시지가 포함된 오류는 'CRITICAL' 등급으로 분류한다")
+    @Test
+    void shouldResolveToCriticalForConnectionRefusedMessage() {
+        // given
+        RuntimeException exception = new RuntimeException("연결 거부");
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.CRITICAL);
+    }
+
+    @DisplayName("서버 내부에서 문제가 생기면(500번 오류) '위험' 등급으로 분류한다")
+    @Test
+    void shouldResolveToHighFor5xxCustomException() {
+        // given
+        ErrorCode mockErrorCode = mock(ErrorCode.class);
+        when(mockErrorCode.defaultHttpStatus()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        CustomException exception = new CustomException(mockErrorCode);
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.HIGH);
+    }
+
+    @DisplayName("사용자가 잘못 요청하면(400번 오류) 'MEDIUM' 등급으로 분류한다")
+    @Test
+    void shouldResolveToMediumFor4xxCustomException() {
+        // given
+        ErrorCode mockErrorCode = mock(ErrorCode.class);
+        when(mockErrorCode.defaultHttpStatus()).thenReturn(HttpStatus.BAD_REQUEST);
+
+        CustomException exception = new CustomException(mockErrorCode);
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.MEDIUM);
+    }
+
+    @DisplayName("정상 처리되었지만 기록이 필요한 경우 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldResolveToInfoFor2xxCustomException() {
+        // given
+        ErrorCode mockErrorCode = mock(ErrorCode.class);
+        when(mockErrorCode.defaultHttpStatus()).thenReturn(HttpStatus.OK);
+
+        CustomException exception = new CustomException(mockErrorCode);
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+
+    @DisplayName("일반적인 프로그램 오류는 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldResolveToInfoForGenericRuntimeException() {
+        // given
+        RuntimeException exception = new RuntimeException();
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+
+    @DisplayName("입력값이 잘못된 경우 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldResolveToInfoForIllegalArgumentException() {
+        // given
+        IllegalArgumentException exception = new IllegalArgumentException("유효하지 않은 파라미터");
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+
+    @DisplayName("오류 설명이 없어도 기본적으로 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldHandleExceptionWithNullMessage() {
+        // given
+        RuntimeException exception = new RuntimeException((String) null);
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+
+    @DisplayName("'연결 거부' 메시지가 없는 연결 오류는 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldNotBeCriticalForNonConnectionRefusedMessage() {
+        // given
+        RuntimeException exception = new RuntimeException("연결 오류");
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+
+    @DisplayName("여러 조건에 해당하는 오류는 가장 심각한 등급으로 분류한다")
+    @Test
+    void shouldApplyCorrectPriorityForComplexConditions() {
+        // given
+        ErrorCode mockErrorCode = mock(ErrorCode.class);
+        when(mockErrorCode.defaultHttpStatus()).thenReturn(HttpStatus.BAD_REQUEST);
+
+        CustomException exception = new CustomException(mockErrorCode) {
+        };
+        DataAccessException dataException = new DataAccessException("DB error", exception) {
+        };
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(dataException);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.CRITICAL);
+    }
+
+    @DisplayName("페이지 이동 안내(300번) 응답은 'INFO' 등급으로 분류한다")
+    @Test
+    void shouldResolveToInfoFor3xxCustomException() {
+        // given
+        ErrorCode mockErrorCode = mock(ErrorCode.class);
+        when(mockErrorCode.defaultHttpStatus()).thenReturn(HttpStatus.MOVED_PERMANENTLY);
+
+        CustomException exception = new CustomException(mockErrorCode);
+
+        // when
+        AlertLevel level = alertLevelResolver.resolveLevel(exception);
+
+        // then
+        assertThat(level).isEqualTo(AlertLevel.INFO);
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SimpleRateLimiterScaleOutTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SimpleRateLimiterScaleOutTest.java
@@ -1,0 +1,167 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("알림 발송 제한 시스템의 멀티 서버 환경 문제 검증")
+class SimpleRateLimiterScaleOutTest {
+
+    private static final ZoneId ZONE_UTC = ZoneId.of("UTC");
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZONE_UTC);
+
+    private static final int INFO_LIMIT = 1;
+    private static final int MEDIUM_LIMIT = 2;
+    private static final int HIGH_LIMIT = 5;
+    private static final int CRITICAL_LIMIT = 10;
+
+    private static SimpleRateLimiter createServerInstance() {
+        return new SimpleRateLimiter(FIXED_CLOCK);
+    }
+
+
+    @DisplayName("두 서버 환경에서 알림이 의도한 제한의 2배로 발송되는 문제")
+    @Test
+    void twoServers_InfoLevel_doublesLimit() {
+        // given
+        SimpleRateLimiter server1 = createServerInstance();
+        SimpleRateLimiter server2 = createServerInstance();
+        String errorCode = "DUPLICATE_ERROR";
+        AlertLevel alertLevel = AlertLevel.INFO;
+
+        // when
+        int allowedByServer1First = server1.shouldSendAlert(errorCode, alertLevel) ? 1 : 0;
+        int allowedByServer1Second = server1.shouldSendAlert(errorCode, alertLevel) ? 1 : 0;
+        int allowedByServer2First = server2.shouldSendAlert(errorCode, alertLevel) ? 1 : 0;
+        int allowedByServer2Second = server2.shouldSendAlert(errorCode, alertLevel) ? 1 : 0;
+
+        int totalAllowed = allowedByServer1First + allowedByServer1Second + allowedByServer2First + allowedByServer2Second;
+
+        // then
+        assertThat(totalAllowed).isEqualTo(2);
+    }
+
+    @DisplayName("서버별 트래픽 분산이 되었을 때 알림 제한이 적용되지 않는 문제")
+    @Test
+    void unbalancedLoad_increasesTotalBeyondGlobalLimit() {
+        // given
+        SimpleRateLimiter heavyTrafficServer = createServerInstance();
+        SimpleRateLimiter lightTrafficServer = createServerInstance();
+        String errorCode = "API_TIMEOUT";
+        AlertLevel alertLevel = AlertLevel.HIGH;
+
+        // when
+        int heavyServerAllowed = sendAttempts(heavyTrafficServer, errorCode, alertLevel, 8);
+        int lightServerAllowed = sendAttempts(lightTrafficServer, errorCode, alertLevel, 2);
+        int totalAllowed = heavyServerAllowed + lightServerAllowed;
+
+        // then
+        assertThat(totalAllowed).isEqualTo(7);
+
+        // 각 서버의 현재 상태 검증
+        assertThat(heavyTrafficServer.shouldSendAlert(errorCode, alertLevel)).isFalse();
+        assertThat(lightTrafficServer.shouldSendAlert(errorCode, alertLevel)).isTrue();
+    }
+
+    @DisplayName("서버 재시작으로 알림 제한 상태가 리셋되어 중복 발송되는 문제")
+    @Test
+    void serverRestart_resetsState_andAllowsAgain() {
+        // given
+        SimpleRateLimiter runningServer = createServerInstance();
+        String errorCode = "RESTART_ERROR";
+        AlertLevel alertLevel = AlertLevel.INFO;
+
+        // when
+        int allowedBeforeRestart = sendAttempts(runningServer, errorCode, alertLevel, 2);
+
+        SimpleRateLimiter restartedServer = createServerInstance();
+        int allowedAfterRestart = sendAttempts(restartedServer, errorCode, alertLevel, 1);
+
+        int totalAllowed = allowedBeforeRestart + allowedAfterRestart;
+
+        // then
+        assertThat(allowedBeforeRestart).isEqualTo(1);
+        assertThat(allowedAfterRestart).isEqualTo(1);
+        assertThat(totalAllowed).isEqualTo(2);
+    }
+
+    @DisplayName("동시 요청 시 서버별로만 제한이 적용되어 전체 발송량이 2배가 되는 문제")
+    @Test
+    void concurrentBursts_onTwoServers_doubleTheGlobalLimit() throws InterruptedException {
+        // given
+        SimpleRateLimiter server1 = createServerInstance();
+        SimpleRateLimiter server2 = createServerInstance();
+        String errorCode = "CONCURRENT_ERROR";
+        AlertLevel alertLevel = AlertLevel.MEDIUM;
+        int requestsPerServer = 10;
+
+        ExecutorService threadPool = Executors.newFixedThreadPool(2);
+        CountDownLatch startSignal = new CountDownLatch(1);
+        CountDownLatch completionSignal = new CountDownLatch(2);
+        AtomicInteger totalAllowedCount = new AtomicInteger(0);
+
+        // when
+        threadPool.submit(() -> runBurst(server1, errorCode, alertLevel, requestsPerServer,
+            startSignal, completionSignal, totalAllowedCount));
+        threadPool.submit(() -> runBurst(server2, errorCode, alertLevel, requestsPerServer,
+            startSignal, completionSignal, totalAllowedCount));
+
+        startSignal.countDown();
+        completionSignal.await();
+        threadPool.shutdown();
+
+        // then
+        assertThat(totalAllowedCount.get()).isEqualTo(4);
+    }
+
+    private static void runBurst(SimpleRateLimiter limiter,
+                                 String errorCode,
+                                 AlertLevel level,
+                                 int attempts,
+                                 CountDownLatch start,
+                                 CountDownLatch done,
+                                 AtomicInteger totalAllowed) {
+        try {
+            start.await();
+            for (int i = 0; i < attempts; i++) {
+                if (limiter.shouldSendAlert(errorCode, level)) {
+                    totalAllowed.incrementAndGet();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private static int sendAttempts(SimpleRateLimiter limiter, String errorCode, AlertLevel level, int attempts) {
+        int allowed = 0;
+        for (int i = 0; i < attempts; i++) {
+            if (limiter.shouldSendAlert(errorCode, level)) {
+                allowed++;
+            }
+        }
+        return allowed;
+    }
+
+    private static int sendAcrossServers(List<SimpleRateLimiter> servers, String errorCode, AlertLevel level, int attemptsPerServer) {
+        int sum = 0;
+        for (SimpleRateLimiter s : servers) {
+            sum += sendAttempts(s, errorCode, level, attemptsPerServer);
+        }
+        return sum;
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SimpleRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SimpleRateLimiterTest.java
@@ -1,0 +1,217 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("알림 전송 빈도 제한 기능 - 과도한 알림을 방지하는 시스템")
+class SimpleRateLimiterTest {
+
+    private SimpleRateLimiter rateLimiter;
+    private Clock fixedClock;
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneId.systemDefault());
+        rateLimiter = new SimpleRateLimiter(fixedClock);
+    }
+
+    @DisplayName("처음 발생하는 오류는 항상 알림을 보낸다")
+    @Test
+    void shouldAllowFirstAlert() {
+        // given
+
+        // when
+        boolean shouldSend = rateLimiter.shouldSendAlert("TEST_ERROR", AlertLevel.CRITICAL);
+
+        // then
+        assertThat(shouldSend).isTrue();
+    }
+
+    @DisplayName("매우 위험한 오류는 10번까지 알림을 보낸 후 차단한다")
+    @Test
+    void shouldLimitCriticalAlerts() {
+        // given
+        String errorCode = "CRITICAL_ERROR";
+        AlertLevel level = AlertLevel.CRITICAL;
+
+        // when: 10번 연속 알림 요청
+        for (int i = 1; i <= 10; i++) {
+            boolean allowed = rateLimiter.shouldSendAlert(errorCode, level);
+
+            // then: 1~10번째는 모두 허용
+            assertThat(allowed).isTrue();
+        }
+
+        // when: 11번째 알림 요청
+        boolean eleventh = rateLimiter.shouldSendAlert(errorCode, level);
+
+        // then: 11번째부터는 차단됨
+        assertThat(eleventh).isFalse();
+    }
+
+    @DisplayName("위험한 오류는 5번까지 알림을 보낸 후 차단한다")
+    @Test
+    void shouldLimitHighAlerts() {
+        // given: 오류 코드와 심각도 설정
+        String errorCode = "HIGH_ERROR";
+        AlertLevel level = AlertLevel.HIGH;
+
+        // when & then: 1~5번째는 허용, 6번째는 차단
+        for (int i = 1; i <= 5; i++) {
+            assertThat(rateLimiter.shouldSendAlert(errorCode, level))
+                .isTrue();
+        }
+        // when: 6번째 요청
+        boolean sixth = rateLimiter.shouldSendAlert(errorCode, level);
+        // then
+        assertThat(sixth).isFalse();
+    }
+
+    @DisplayName("보통 수준 오류는 2번까지 알림을 보낸 후 차단한다")
+    @Test
+    void shouldLimitMediumAlerts() {
+        // given
+        String errorCode = "MEDIUM_ERROR";
+        AlertLevel level = AlertLevel.MEDIUM;
+
+        // when & then: 1~2번째는 허용, 3번째는 차단
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        // when: 3번째 요청
+        boolean third = rateLimiter.shouldSendAlert(errorCode, level);
+        // then
+        assertThat(third).isFalse();
+    }
+
+    @DisplayName("정보성 알림은 1번만 보낸 후 차단한다")
+    @Test
+    void shouldLimitInfoAlerts() {
+        // given
+        String errorCode = "INFO_ERROR";
+        AlertLevel level = AlertLevel.INFO;
+
+        // when: 첫 번째 요청
+        boolean first = rateLimiter.shouldSendAlert(errorCode, level);
+        // then
+        assertThat(first).isTrue();
+
+        // when: 두 번째 요청
+        boolean second = rateLimiter.shouldSendAlert(errorCode, level);
+        // then
+        assertThat(second).isFalse();
+    }
+
+    @DisplayName("서로 다른 종류의 오류는 각각 독립적으로 알림 제한을 적용한다")
+    @Test
+    void shouldLimitIndependentlyByErrorCode() {
+        // given: 두 개의 오류 코드
+        String errorCode1 = "ERROR_1";
+        String errorCode2 = "ERROR_2";
+        AlertLevel level = AlertLevel.INFO;
+
+        // when & then: 각각 첫 요청은 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode1, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode2, level)).isTrue();
+
+        // when & then: 각각 두 번째 요청은 차단
+        assertThat(rateLimiter.shouldSendAlert(errorCode1, level)).isFalse();
+        assertThat(rateLimiter.shouldSendAlert(errorCode2, level)).isFalse();
+    }
+
+    @DisplayName("같은 오류라도 위험의 수준이 다르면 각각 독립적으로 알림 제한을 적용한다")
+    @Test
+    void shouldLimitIndependentlyByAlertLevel() {
+        // given
+        String errorCode = "TEST_ERROR";
+
+        // when & then: CRITICAL 레벨은 첫 요청 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.CRITICAL)).isTrue();
+
+        // when & then: INFO 레벨은 별도 카운트로 첫 요청 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.INFO)).isTrue();
+
+        // when: INFO 레벨 두 번째 요청
+        boolean infoSecond = rateLimiter.shouldSendAlert(errorCode, AlertLevel.INFO);
+        // then
+        assertThat(infoSecond).isFalse();
+
+        // when & then: CRITICAL 레벨 카운트는 그대로 유지되어 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.CRITICAL)).isTrue();
+    }
+
+    @DisplayName("일정 시간이 지나면 알림 제한이 초기화되어 다시 알림을 보낼 수 있다")
+    @Test
+    void shouldResetAfterTimeWindow() {
+        // given: 제한 도달 상태
+        String errorCode = "TEST_ERROR";
+        AlertLevel level = AlertLevel.INFO;
+        rateLimiter.shouldSendAlert(errorCode, level);
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+
+        // when: 일정 시간이 지난 후 새로운 처리율 제한 객체 생성
+        Clock newClock = Clock.fixed(
+            Instant.parse("2023-01-01T00:06:00Z"),
+            ZoneId.systemDefault()
+        );
+        rateLimiter = new SimpleRateLimiter(newClock);
+
+        // then: 다시 알림 허용됨
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+    }
+
+    @DisplayName("수동으로 초기화하면 모든 알림 제한이 해제된다")
+    @Test
+    void shouldResetAllLimits() {
+        // given: 제한 도달 상태
+        String errorCode = "TEST_ERROR";
+        AlertLevel level = AlertLevel.INFO;
+        rateLimiter.shouldSendAlert(errorCode, level);
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+
+        // when: reset 호출
+        rateLimiter.reset();
+
+        // then: 모든 제한이 해제되어 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+    }
+
+    @DisplayName("여러 요청이 동시에 들어와도 정확한 수만큼만 알림을 허용한다")
+    @Test
+    void shouldBeThreadSafe() throws InterruptedException {
+        // given: 동시에 요청할 갯수와 제한 설정
+        String errorCode = "CONCURRENT_ERROR";
+        AlertLevel level = AlertLevel.HIGH; // 최대 5회 허용
+        int threadCount = 10;
+
+        // when: ExecutorService와 CountDownLatch로 동시 처리
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                if (rateLimiter.shouldSendAlert(errorCode, level)) {
+                    successCount.incrementAndGet();
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+        executor.shutdown();
+
+        // then: 정확히 5개의 요청만 허용됨
+        assertThat(successCount.get()).isEqualTo(5);
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SlackMessageBuilderTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SlackMessageBuilderTest.java
@@ -1,0 +1,68 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.constants.AlertConstants;
+import com.eventitta.common.notification.domain.AlertLevel;
+import com.eventitta.common.notification.domain.SlackMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("슬랙 메시지 빌더 기본 기능")
+class SlackMessageBuilderTest {
+
+    private SlackMessageBuilder messageBuilder;
+
+    @BeforeEach
+    void setUp() {
+        messageBuilder = new SlackMessageBuilder();
+    }
+
+    @DisplayName("메시지 텍스트와 컬러가 레벨에 맞게 설정된다")
+    @Test
+    void shouldFormatMessageAccordingToLevel() {
+        // given
+        AlertLevel[] levels = {AlertLevel.CRITICAL, AlertLevel.HIGH, AlertLevel.MEDIUM, AlertLevel.INFO};
+        String errorCode = "ERROR";
+        String body = "Test";
+
+        // when & then
+        for (AlertLevel level : levels) {
+            SlackMessage msg = messageBuilder.buildMessage(
+                level, errorCode, body, null, null, null, "env", "#chan", "bot"
+            );
+            String expectedText = ":warning: " + level + " Alert";
+            String expectedColor = switch (level) {
+                case CRITICAL -> AlertConstants.CRITICAL_COLOR;
+                case HIGH -> AlertConstants.HIGH_COLOR;
+                case MEDIUM -> AlertConstants.MEDIUM_COLOR;
+                default -> AlertConstants.INFO_COLOR;
+            };
+            assertThat(msg.text()).isEqualTo(expectedText);
+            assertThat(msg.attachments()).hasSize(1);
+            assertThat(msg.attachments().get(0).color()).isEqualTo(expectedColor);
+        }
+    }
+
+    @DisplayName("Critical 레벨에서만 예외 정보가 포함되고, 그 외에는 제외된다")
+    @Test
+    void shouldIncludeOrExcludeException() {
+        // given
+        Exception ex = new RuntimeException("fail");
+
+        // when
+        SlackMessage criticalMsg = messageBuilder.buildMessage(
+            AlertLevel.CRITICAL, "ERR", "msg", null, null, ex, "env", "#c", "b"
+        );
+        SlackMessage infoMsg = messageBuilder.buildMessage(
+            AlertLevel.INFO, "ERR", "msg", null, null, ex, "env", "#c", "b"
+        );
+
+        // then
+        assertThat(criticalMsg.attachments().get(0).fields()).anySatisfy(f ->
+            assertThat(f.getTitle()).isEqualTo("Exception")
+        );
+        assertThat(infoMsg.attachments().get(0).fields()).isEmpty();
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SlackNotificationServiceTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SlackNotificationServiceTest.java
@@ -1,0 +1,176 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.config.SlackProperties;
+import com.eventitta.common.notification.domain.AlertLevel;
+import com.eventitta.common.notification.domain.SlackMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("슬랙 알림 서비스 핵심 기능")
+@ExtendWith(MockitoExtension.class)
+class SlackNotificationServiceTest {
+
+    @Mock
+    private SlackProperties slackProperties;
+    @Mock
+    private RateLimiter rateLimiter;
+    @Mock
+    private RestClient slackRestClient;
+    @Mock
+    private Environment environment;
+    @Mock
+    private SlackMessageBuilder messageBuilder;
+    @Mock
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+    @Mock
+    private RestClient.RequestBodySpec requestBodySpec;
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private SlackNotificationService slackNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        slackNotificationService = new SlackNotificationService(
+            slackProperties, rateLimiter, slackRestClient, environment, messageBuilder
+        );
+    }
+
+    @DisplayName("슬랙 비활성화 시에는 전송 하지 않는다")
+    @Test
+    void shouldNotSendWhenSlackIsDisabled() {
+        // given
+        when(slackProperties.isEnabled()).thenReturn(false);
+
+        // when
+        slackNotificationService.sendAlert(
+            AlertLevel.CRITICAL, "TEST_ERROR", "Test message",
+            "/api/test", "user123", new RuntimeException("Test")
+        );
+
+        // then
+        verifyNoInteractions(rateLimiter, messageBuilder, slackRestClient);
+    }
+
+    @DisplayName("요청 횟수 제한인 경우에는 예외를 발송하지 않는다")
+    @Test
+    void shouldNotSendWhenRateLimited() {
+        // given
+        when(slackProperties.isEnabled()).thenReturn(true);
+        when(rateLimiter.shouldSendAlert("TEST_ERROR", AlertLevel.HIGH)).thenReturn(false);
+
+        // when
+        slackNotificationService.sendAlert(
+            AlertLevel.HIGH, "TEST_ERROR", "Test message",
+            "/api/test", "user123", null
+        );
+
+        // then
+        verify(rateLimiter).shouldSendAlert("TEST_ERROR", AlertLevel.HIGH);
+        verifyNoInteractions(messageBuilder, slackRestClient);
+    }
+
+    @DisplayName("정상 조건에서 슬랙 전송을 성공한다")
+    @Test
+    void shouldSendSlackAlertWhenConditionsMet() {
+        // given
+        setupSuccessfulSlackSend();
+
+        SlackMessage expectedMessage = SlackMessage.builder()
+            .channel("#alerts")
+            .username("eventitta-bot")
+            .text("Test alert")
+            .build();
+
+        when(messageBuilder.buildMessage(
+            eq(AlertLevel.CRITICAL), eq("API_ERROR"), eq("Database connection failed"),
+            eq("/api/users"), eq("user123@example.com"), any(RuntimeException.class),
+            eq("local"), eq("#alerts"), eq("eventitta-bot")
+        )).thenReturn(expectedMessage);
+
+        // when
+        slackNotificationService.sendAlert(
+            AlertLevel.CRITICAL, "API_ERROR", "Database connection failed",
+            "/api/users", "user123@example.com", new RuntimeException("Connection timeout")
+        );
+
+        // then
+        verify(rateLimiter).shouldSendAlert("API_ERROR", AlertLevel.CRITICAL);
+        verify(messageBuilder).buildMessage(
+            eq(AlertLevel.CRITICAL), eq("API_ERROR"), eq("Database connection failed"),
+            eq("/api/users"), eq("user123@example.com"), any(RuntimeException.class),
+            eq("local"), eq("#alerts"), eq("eventitta-bot")
+        );
+        verify(slackRestClient).post();
+        verify(requestBodyUriSpec).uri("https://hooks.slack.com/test");
+        verify(requestBodySpec).body(expectedMessage);
+    }
+
+    @DisplayName("네트워크 오류가 발생해도 애플리케이션이 중단되지 않는다")
+    @Test
+    void shouldHandleSlackSendException() {
+        // given
+        setupSlackSendWithNetworkError();
+
+        // when - 예외가 발생해도 정상 종료되어야 함
+        slackNotificationService.sendAlert(
+            AlertLevel.HIGH, "ERROR_CODE", "Test error",
+            "/api/test", "user", new RuntimeException("Original error")
+        );
+
+        // then
+        verify(rateLimiter).shouldSendAlert("ERROR_CODE", AlertLevel.HIGH);
+        verify(messageBuilder).buildMessage(
+            any(), anyString(), anyString(), anyString(), anyString(), any(),
+            anyString(), anyString(), anyString()
+        );
+        verify(slackRestClient).post();
+    }
+
+    private void setupSuccessfulSlackSend() {
+        when(slackProperties.isEnabled()).thenReturn(true);
+        when(slackProperties.getWebhookUrl()).thenReturn("https://hooks.slack.com/test");
+        when(slackProperties.getChannel()).thenReturn("#alerts");
+        when(slackProperties.getUsername()).thenReturn("eventitta-bot");
+        when(environment.getActiveProfiles()).thenReturn(new String[]{"local"});
+        when(rateLimiter.shouldSendAlert("API_ERROR", AlertLevel.CRITICAL)).thenReturn(true);
+
+        // RestClient mock chain
+        when(slackRestClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(any())).thenReturn(requestBodySpec);
+        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.toBodilessEntity()).thenReturn(null);
+    }
+
+    private void setupSlackSendWithNetworkError() {
+        when(slackProperties.isEnabled()).thenReturn(true);
+        when(slackProperties.getWebhookUrl()).thenReturn("https://hooks.slack.com/test");
+        when(slackProperties.getChannel()).thenReturn("#alerts");
+        when(slackProperties.getUsername()).thenReturn("eventitta-bot");
+        when(environment.getActiveProfiles()).thenReturn(new String[]{"test"});
+        when(rateLimiter.shouldSendAlert("ERROR_CODE", AlertLevel.HIGH)).thenReturn(true);
+
+        SlackMessage mockMessage = SlackMessage.builder().build();
+        when(messageBuilder.buildMessage(
+            any(), anyString(), anyString(), anyString(), anyString(), any(),
+            anyString(), anyString(), anyString()
+        )).thenReturn(mockMessage);
+
+        // RestClient에서 예외 발생 설정
+        when(slackRestClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri("https://hooks.slack.com/test")).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(any())).thenThrow(new RuntimeException("Network error"));
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the notification alert system, covering alert level resolution, Slack message formatting, and rate limiting logic. The new tests verify correct behavior for various error scenarios, alert levels, and edge cases, ensuring robustness and reliability of the notification features.

**Alert Level Resolution Tests** (`AlertLevelResolverTest.java`):

* Added tests to verify that different exception types and HTTP status codes are mapped to the correct `AlertLevel` (e.g., CRITICAL for DB connection errors, HIGH for 5xx, MEDIUM for 4xx, INFO for normal or input errors). Also ensures priority logic for complex nested exceptions.

**Rate Limiting Tests** (`SimpleRateLimiterTest.java`, `SimpleRateLimiterScaleOutTest.java`):

* Added tests for per-error and per-level rate limiting, time-based resets, manual resets, and thread safety to confirm that only the allowed number of alerts are sent per configuration.
* Added scale-out tests simulating multi-server environments, verifying issues such as doubled alert counts, unbalanced traffic, server restarts, and concurrency, to highlight distributed rate limiting limitations.

**Slack Message Formatting Tests** (`SlackMessageBuilderTest.java`):

* Added tests to validate that Slack messages are formatted with the correct text and color per alert level, and that exception details are included only for CRITICAL alerts.