### PR TITLE
feat: improve rate limiter algorithms

### DIFF
--- a/src/jmh/java/com/eventitta/common/notification/service/CacheBasedRateLimiterBenchmark.java
+++ b/src/jmh/java/com/eventitta/common/notification/service/CacheBasedRateLimiterBenchmark.java
@@ -4,9 +4,6 @@ import com.eventitta.common.notification.domain.AlertLevel;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -21,7 +18,6 @@ public class CacheBasedRateLimiterBenchmark {
     int mapSize;
 
     private CacheBasedRateLimiter limiter;
-    private Clock fixedClock;
     private String[] existingKeys;
 
     @State(Scope.Thread)
@@ -31,8 +27,7 @@ public class CacheBasedRateLimiterBenchmark {
 
     @Setup(Level.Trial)
     public void setup() {
-        fixedClock = Clock.fixed(Instant.parse("2025-01-01T00:00:00Z"), ZoneOffset.UTC);
-        limiter = new CacheBasedRateLimiter(fixedClock);
+        limiter = new CacheBasedRateLimiter();
 
         for (int i = 0; i < mapSize; i++) {
             limiter.shouldSendAlert("EXISTING_KEY_" + i, AlertLevel.INFO);

--- a/src/main/java/com/eventitta/common/notification/constants/AlertConstants.java
+++ b/src/main/java/com/eventitta/common/notification/constants/AlertConstants.java
@@ -4,17 +4,7 @@ public final class AlertConstants {
 
     public static final String CONNECTION_REFUSED_MESSAGE = "Connection refused";
 
-    public static final String CRITICAL_COLOR = "#FF0000"; // Red
-    public static final String HIGH_COLOR = "#FF8C00";     // Orange
-    public static final String MEDIUM_COLOR = "#FFD700";   // Yellow
-    public static final String INFO_COLOR = "#00FF00";     // Green
-
     public static final String DEFAULT_ALERT_CHANNEL = "#alerts";
-
-    public static final int CRITICAL_ALERT_LIMIT = 10;
-    public static final int HIGH_ALERT_LIMIT = 5;
-    public static final int MEDIUM_ALERT_LIMIT = 2;
-    public static final int INFO_ALERT_LIMIT = 1;
 
     public static final String ALERT_EMOJI = ":warning:";
     public static final String ALERT_TEXT_FORMAT = "%s %s Alert";

--- a/src/main/java/com/eventitta/common/notification/domain/AlertLevel.java
+++ b/src/main/java/com/eventitta/common/notification/domain/AlertLevel.java
@@ -1,8 +1,24 @@
 package com.eventitta.common.notification.domain;
 
 public enum AlertLevel {
-    CRITICAL,
-    HIGH,
-    MEDIUM,
-    INFO
+    CRITICAL(10, "#FF0000"),
+    HIGH(5, "#FF8C00"),
+    MEDIUM(2, "#FFD700"),
+    INFO(1, "#00FF00");
+
+    private final int alertLimit;
+    private final String color;
+
+    AlertLevel(int alertLimit, String color) {
+        this.alertLimit = alertLimit;
+        this.color = color;
+    }
+
+    public int getAlertLimit() {
+        return alertLimit;
+    }
+
+    public String getColor() {
+        return color;
+    }
 }

--- a/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
@@ -7,7 +7,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.springframework.stereotype.Component;
 
-import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -17,14 +16,8 @@ public class CacheBasedRateLimiter implements RateLimiter {
     private static final String KEY_SEPARATOR = ":";
 
     private final Cache<String, AtomicInteger> alertCounts;
-    private final Clock clock;
 
     public CacheBasedRateLimiter() {
-        this(Clock.systemDefaultZone());
-    }
-
-    public CacheBasedRateLimiter(Clock clock) {
-        this.clock = clock;
         this.alertCounts = Caffeine.newBuilder()
             .maximumSize(10000)
             .expireAfterWrite(AlertConstants.RATE_LIMIT_WINDOW_MINUTES, TimeUnit.MINUTES)
@@ -52,12 +45,7 @@ public class CacheBasedRateLimiter implements RateLimiter {
     }
 
     private int getMaxAlertsPerPeriod(AlertLevel level) {
-        return switch (level) {
-            case CRITICAL -> AlertConstants.CRITICAL_ALERT_LIMIT;
-            case HIGH -> AlertConstants.HIGH_ALERT_LIMIT;
-            case MEDIUM -> AlertConstants.MEDIUM_ALERT_LIMIT;
-            case INFO -> AlertConstants.INFO_ALERT_LIMIT;
-        };
+        return level.getAlertLimit();
     }
 
     public CacheStats getCacheStats() {

--- a/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
@@ -35,10 +35,10 @@ public class CacheBasedRateLimiter implements RateLimiter {
     @Override
     public boolean shouldSendAlert(String errorCode, AlertLevel level) {
         String key = createKey(errorCode, level);
-        
+
         AtomicInteger count = alertCounts.get(key, k -> new AtomicInteger(0));
         int currentCount = count.incrementAndGet();
-        
+
         return currentCount <= getMaxAlertsPerPeriod(level);
     }
 

--- a/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/CacheBasedRateLimiter.java
@@ -13,8 +13,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class CacheBasedRateLimiter implements RateLimiter {
 
-    private static final String KEY_SEPARATOR = ":";
-
     private final Cache<String, AtomicInteger> alertCounts;
 
     public CacheBasedRateLimiter() {
@@ -38,14 +36,6 @@ public class CacheBasedRateLimiter implements RateLimiter {
     @Override
     public void reset() {
         alertCounts.invalidateAll();
-    }
-
-    private String createKey(String errorCode, AlertLevel level) {
-        return errorCode + KEY_SEPARATOR + level;
-    }
-
-    private int getMaxAlertsPerPeriod(AlertLevel level) {
-        return level.getAlertLimit();
     }
 
     public CacheStats getCacheStats() {

--- a/src/main/java/com/eventitta/common/notification/service/FixedWindowRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/FixedWindowRateLimiter.java
@@ -57,8 +57,4 @@ public class FixedWindowRateLimiter implements RateLimiter {
         }
         return true;
     }
-
-    private int getMaxAlertsPerPeriod(AlertLevel level) {
-        return level.getAlertLimit();
-    }
 }

--- a/src/main/java/com/eventitta/common/notification/service/FixedWindowRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/FixedWindowRateLimiter.java
@@ -1,0 +1,64 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+@RequiredArgsConstructor
+public class FixedWindowRateLimiter implements RateLimiter {
+
+    private final ConcurrentHashMap<String, AtomicInteger> alerts = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    private static final long WINDOW_SIZE_MILLIS = 60000; // 1분
+    public static final long CLEANUP_LOOKBACK_MILLIS = WINDOW_SIZE_MILLIS * 2;
+
+    @Override
+    public boolean shouldSendAlert(String errorCode, AlertLevel level) {
+        long now = clock.millis();
+        long startWindowMillis = (now / WINDOW_SIZE_MILLIS) * WINDOW_SIZE_MILLIS;
+        String key = errorCode + ":" + level + ":" + startWindowMillis;
+
+        AtomicInteger count = alerts.computeIfAbsent(key, (k) -> new AtomicInteger(0));
+        int currentCount = count.incrementAndGet();
+        int maxAlertsPerPeriod = getMaxAlertsPerPeriod(level);
+
+        return currentCount <= maxAlertsPerPeriod;
+    }
+
+    @Override
+    public void reset() {
+        alerts.clear();
+    }
+
+    @Scheduled(fixedRate = 300000)
+    public void cleanUpAlerts() {
+        long now = clock.millis();
+        long cutoffTime = now - CLEANUP_LOOKBACK_MILLIS;
+
+        alerts.entrySet().removeIf(entry -> isExpiredKey(entry.getKey(), cutoffTime));
+    }
+
+    private boolean isExpiredKey(String key, long cutoffTime) {
+        String[] parts = key.split(":");
+        if (parts.length >= 3) {
+            try {
+                long windowMillis = Long.parseLong(parts[2]);
+                return windowMillis <= cutoffTime;
+            } catch (NumberFormatException e) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+    private int getMaxAlertsPerPeriod(AlertLevel level) {
+        return level.getAlertLimit();
+    }
+}

--- a/src/main/java/com/eventitta/common/notification/service/RateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/RateLimiter.java
@@ -4,5 +4,14 @@ import com.eventitta.common.notification.domain.AlertLevel;
 
 public interface RateLimiter {
     boolean shouldSendAlert(String errorCode, AlertLevel level);
+
     void reset();
+
+    default String createKey(String errorCode, AlertLevel level) {
+        return errorCode + ":" + level;
+    }
+
+    default int getMaxAlertsPerPeriod(AlertLevel level) {
+        return level.getAlertLimit();
+    }
 }

--- a/src/main/java/com/eventitta/common/notification/service/SimpleRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/SimpleRateLimiter.java
@@ -58,12 +58,7 @@ public class SimpleRateLimiter implements RateLimiter {
     }
 
     private int getMaxAlertsPerPeriod(AlertLevel level) {
-        return switch (level) {
-            case CRITICAL -> AlertConstants.CRITICAL_ALERT_LIMIT;
-            case HIGH -> AlertConstants.HIGH_ALERT_LIMIT;
-            case MEDIUM -> AlertConstants.MEDIUM_ALERT_LIMIT;
-            case INFO -> AlertConstants.INFO_ALERT_LIMIT;
-        };
+        return level.getAlertLimit();
     }
 
     private static class AlertRecord {

--- a/src/main/java/com/eventitta/common/notification/service/SimpleRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/SimpleRateLimiter.java
@@ -12,8 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class SimpleRateLimiter implements RateLimiter {
 
-    private static final String KEY_SEPARATOR = ":";
-
     private final ConcurrentHashMap<String, AlertRecord> alerts = new ConcurrentHashMap<>();
     private final Clock clock;
 
@@ -47,18 +45,10 @@ public class SimpleRateLimiter implements RateLimiter {
         alerts.clear();
     }
 
-    private String createKey(String errorCode, AlertLevel level) {
-        return errorCode + KEY_SEPARATOR + level;
-    }
-
     private void cleanupExpiredRecords(long now) {
         long windowMillis = TimeUnit.MINUTES.toMillis(AlertConstants.RATE_LIMIT_WINDOW_MINUTES);
         alerts.entrySet().removeIf(entry ->
             now - entry.getValue().getTimestamp() > windowMillis);
-    }
-
-    private int getMaxAlertsPerPeriod(AlertLevel level) {
-        return level.getAlertLimit();
     }
 
     private static class AlertRecord {

--- a/src/main/java/com/eventitta/common/notification/service/SlackMessageBuilder.java
+++ b/src/main/java/com/eventitta/common/notification/service/SlackMessageBuilder.java
@@ -80,12 +80,7 @@ public class SlackMessageBuilder {
     }
 
     private String getColorForLevel(AlertLevel level) {
-        return switch (level) {
-            case CRITICAL -> AlertConstants.CRITICAL_COLOR;
-            case HIGH -> AlertConstants.HIGH_COLOR;
-            case MEDIUM -> AlertConstants.MEDIUM_COLOR;
-            case INFO -> AlertConstants.INFO_COLOR;
-        };
+        return level.getColor();
     }
 
     private String getShortStackTrace(Throwable exception) {

--- a/src/main/java/com/eventitta/common/notification/service/SlidingWindowCounterRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/SlidingWindowCounterRateLimiter.java
@@ -1,0 +1,84 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+@RequiredArgsConstructor
+public class SlidingWindowCounterRateLimiter implements RateLimiter {
+
+    private final ConcurrentHashMap<String, AtomicInteger> alerts = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    private static final long BUCKET_SIZE_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    private static final int NUM_BUCKETS = 5;
+    private static final long WINDOW_SIZE_MILLIS = NUM_BUCKETS * BUCKET_SIZE_MILLIS;
+
+    @Override
+    public boolean shouldSendAlert(String errorCode, AlertLevel level) {
+        long now = clock.millis();
+        long currentBucketStart = (now / BUCKET_SIZE_MILLIS) * BUCKET_SIZE_MILLIS;
+        String currentKey = errorCode + ":" + level + ":" + currentBucketStart;
+
+        int currentTotal = calculateTotalCountInWindow(errorCode, level, currentBucketStart);
+        int limitCount = getMaxAlertsPerPeriod(level);
+
+        if (currentTotal >= limitCount) {
+            return false;
+        }
+
+        AtomicInteger count = alerts.computeIfAbsent(currentKey, k -> new AtomicInteger(0));
+        count.incrementAndGet();
+        return true;
+    }
+
+    private int calculateTotalCountInWindow(String errorCode, AlertLevel level, long currentBucketStart) {
+        int totalCount = 0;
+        for (int i = 0; i < NUM_BUCKETS; i++) {
+            long bucketStart = currentBucketStart - (BUCKET_SIZE_MILLIS * i);
+            String bucketKey = errorCode + ":" + level + ":" + bucketStart;
+
+            AtomicInteger bucketCount = alerts.get(bucketKey);
+            if (bucketCount != null) {
+                totalCount += bucketCount.get();
+            }
+        }
+        return totalCount;
+    }
+
+    @Scheduled(fixedRate = 300000)
+    public void scheduledCleanup() {
+        long now = clock.millis();
+        long cutoffTime = now - (WINDOW_SIZE_MILLIS * 2);
+
+        alerts.entrySet().removeIf(entry -> {
+            String key = entry.getKey();
+            return isExpiredKey(key, cutoffTime);
+        });
+    }
+
+    private boolean isExpiredKey(String key, long cutoffTime) {
+        String[] parts = key.split(":");
+        if (parts.length >= 3) {
+            try {
+                long bucketTimestamp = Long.parseLong(parts[2]);
+                return bucketTimestamp < cutoffTime;
+            } catch (NumberFormatException e) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void reset() {
+        alerts.clear();
+    }
+}

--- a/src/main/java/com/eventitta/common/notification/service/SlidingWindowLogRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/SlidingWindowLogRateLimiter.java
@@ -1,0 +1,40 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static com.eventitta.common.notification.constants.AlertConstants.RATE_LIMIT_WINDOW_MINUTES;
+
+@Component
+@RequiredArgsConstructor
+public class SlidingWindowLogRateLimiter implements RateLimiter {
+
+    private final ConcurrentHashMap<String, List<Long>> alerts = new ConcurrentHashMap<>();
+    private final Clock clock;
+    private final long RATE_LIMIT_WINDOW_MILLIS = TimeUnit.MINUTES.toMillis(RATE_LIMIT_WINDOW_MINUTES);
+
+    @Override
+    public boolean shouldSendAlert(String errorCode, AlertLevel level) {
+        String key = createKey(errorCode, level);
+
+        List<Long> timestamps = alerts.computeIfAbsent(key, k -> new ArrayList<>());
+        long now = clock.millis();
+        timestamps.removeIf(ts -> ts <= now - RATE_LIMIT_WINDOW_MILLIS);
+        timestamps.add(now);
+        int maxAlerts = getMaxAlertsPerPeriod(level);
+        return timestamps.size() <= maxAlerts;
+    }
+
+    @Override
+    public void reset() {
+        alerts.clear();
+    }
+
+}

--- a/src/main/java/com/eventitta/common/notification/service/TokenBucketRateLimiter.java
+++ b/src/main/java/com/eventitta/common/notification/service/TokenBucketRateLimiter.java
@@ -1,0 +1,53 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class TokenBucketRateLimiter implements RateLimiter {
+    private final ConcurrentHashMap<String, TokenBucket> alerts = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    @Override
+    public boolean shouldSendAlert(String errorCode, AlertLevel level) {
+        long currentMillis = clock.millis();
+        String key = createKey(errorCode, level);
+        int capacity = getMaxAlertsPerPeriod(level);
+
+        TokenBucket tokenBucket = alerts.computeIfAbsent(key, k -> new TokenBucket(currentMillis, capacity));
+        double refillRate = (double) capacity / TimeUnit.MINUTES.toMillis(5);
+        long newTokens = (long) ((currentMillis - tokenBucket.timestamp) * refillRate);
+        if (newTokens > 0) {
+            tokenBucket.tokenCount = Math.min(capacity, tokenBucket.tokenCount + newTokens);
+            tokenBucket.timestamp = currentMillis;
+        }
+
+        if (tokenBucket.tokenCount >= 1) {
+            tokenBucket.tokenCount--;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void reset() {
+        alerts.clear();
+    }
+
+    private static class TokenBucket {
+        long timestamp;
+        long tokenCount;
+
+        public TokenBucket(long timestamp, long tokenCount) {
+            this.timestamp = timestamp;
+            this.tokenCount = tokenCount;
+        }
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/resolver/AlertLevelResolverTest.java
+++ b/src/test/java/com/eventitta/common/notification/resolver/AlertLevelResolverTest.java
@@ -52,11 +52,11 @@ class AlertLevelResolverTest {
         assertThat(level).isEqualTo(AlertLevel.CRITICAL);
     }
 
-    @DisplayName("'연결 거부' 메시지가 포함된 오류는 'CRITICAL' 등급으로 분류한다")
+    @DisplayName("'Connection 관련' 오류는 'CRITICAL' 등급으로 분류한다")
     @Test
     void shouldResolveToCriticalForConnectionRefusedMessage() {
         // given
-        RuntimeException exception = new RuntimeException("연결 거부");
+        ConnectException exception = new ConnectException("Connection failed");
 
         // when
         AlertLevel level = alertLevelResolver.resolveLevel(exception);

--- a/src/test/java/com/eventitta/common/notification/service/CacheBasedRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/CacheBasedRateLimiterTest.java
@@ -1,0 +1,201 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CacheBasedRateLimiterTest {
+
+    private CacheBasedRateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new CacheBasedRateLimiter();
+    }
+
+    @Test
+    @DisplayName("첫 번째 알림 요청은 항상 허용되어야 한다")
+    void shouldAllowFirstAlert() {
+        // given
+
+        // when
+        boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.HIGH);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(AlertLevel.class)
+    @DisplayName("각 레벨별 제한값이 올바르게 적용되어야 한다")
+    void shouldApplyCorrectLimitsForEachLevel(AlertLevel level) {
+        // given
+        String errorCode = "PARAM_TEST_" + level; // 레벨별로 다른 키 사용
+        int expectedLimit = level.getAlertLimit();
+
+        // when & then: 제한까지 허용
+        for (int i = 0; i < expectedLimit; i++) {
+            // when
+            boolean allowed = rateLimiter.shouldSendAlert(errorCode, level);
+            // then
+            assertThat(allowed).isTrue();
+        }
+
+        // when: 초과 요청
+        boolean afterLimit = rateLimiter.shouldSendAlert(errorCode, level);
+        // then: 초과시 거부
+        assertThat(afterLimit).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("다른 에러 코드는 독립적으로 카운트되어야 한다")
+    void shouldCountDifferentErrorCodesIndependently() {
+        // given
+        AlertLevel level = AlertLevel.HIGH;
+
+        // when
+        boolean result1 = rateLimiter.shouldSendAlert("ERROR_001", level);
+        boolean result2 = rateLimiter.shouldSendAlert("ERROR_002", level);
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("같은 에러 코드라도 다른 레벨은 독립적으로 카운트되어야 한다")
+    void shouldCountDifferentLevelsIndependently() {
+        // given
+        String errorCode = "ERROR_001";
+
+        // when
+        boolean highResult = rateLimiter.shouldSendAlert(errorCode, AlertLevel.HIGH);
+        boolean mediumResult = rateLimiter.shouldSendAlert(errorCode, AlertLevel.MEDIUM);
+
+        // then
+        assertThat(highResult).isTrue();
+        assertThat(mediumResult).isTrue();
+
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("reset() 호출 시 모든 카운트가 초기화되어야 한다")
+    void shouldResetAllCountsWhenReset() {
+        // given
+        rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.HIGH);
+        rateLimiter.shouldSendAlert("ERROR_002", AlertLevel.MEDIUM);
+
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(2);
+
+        // when
+        rateLimiter.reset();
+
+        // then
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(0);
+
+        // when
+        boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.HIGH);
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("캐시 통계를 조회할 수 있어야 한다")
+    void shouldProvidesCacheStats() {
+        // given
+        rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.HIGH);
+        rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.HIGH);
+
+        // when
+        var stats = rateLimiter.getCacheStats();
+
+        // then
+        assertThat(stats.requestCount()).isEqualTo(2);
+        assertThat(stats.hitCount()).isEqualTo(1);
+        assertThat(stats.missCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("연속된 요청이 올바르게 제한되어야 한다")
+    void shouldLimitConsecutiveRequests() {
+        // given
+        String errorCode = "SEQUENTIAL_TEST";
+        AlertLevel level = AlertLevel.MEDIUM;
+
+        // when & then: 첫 2개 요청은 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+
+        // when & then: 그 이후 요청들은 모두 거부
+        for (int i = 0; i < 5; i++) {
+            // when
+            boolean blocked = rateLimiter.shouldSendAlert(errorCode, level);
+            // then
+            assertThat(blocked).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("수동 정리는 만료되지 않은 엔트리에 영향을 주지 않는다")
+        // 설명: cleanUp() 호출이 만료되지 않은 항목에는 영향을 주지 않는지 확인합니다.
+    void shouldNotAffectNonExpiredEntriesAfterCleanup() {
+        // given
+        assertThat(rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.INFO)).isFalse();
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(1);
+
+        // when
+        rateLimiter.cleanUp();
+
+        // then
+        assertThat(rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.INFO)).isFalse();
+        assertThat(rateLimiter.getCacheSize()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("캐시 히트율이 올바르게 계산되어야 한다")
+    void shouldCalculateHitRateCorrectly() {
+        // given
+        String errorCode = "STATS_TEST";
+        AlertLevel level = AlertLevel.HIGH;
+
+        // when: 첫 번째: miss (캐시에 없음)
+        rateLimiter.shouldSendAlert(errorCode, level);
+
+        // when: 두 번째: hit (캐시에 있음)
+        rateLimiter.shouldSendAlert(errorCode, level);
+
+        // then
+        var stats = rateLimiter.getCacheStats();
+        assertThat(stats.missCount()).isEqualTo(1);
+        assertThat(stats.hitCount()).isEqualTo(1);
+        assertThat(stats.hitRate()).isEqualTo(0.5, Offset.offset(0.01));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 에러코드 처리")
+    void shouldHandleEmptyErrorCode() {
+        // given
+
+        // when
+        boolean result = rateLimiter.shouldSendAlert("", AlertLevel.INFO);
+        // then
+        assertThat(result).isTrue();
+
+        // when
+        boolean secondResult = rateLimiter.shouldSendAlert("", AlertLevel.INFO);
+        // then
+        assertThat(secondResult).isFalse();
+    }
+
+}

--- a/src/test/java/com/eventitta/common/notification/service/FixedWindowRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/FixedWindowRateLimiterTest.java
@@ -1,0 +1,236 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.eventitta.common.notification.service.FixedWindowRateLimiter.CLEANUP_LOOKBACK_MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FixedWindowRateLimiterTest {
+
+    @Mock
+    private Clock clock;
+
+    private FixedWindowRateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new FixedWindowRateLimiter(clock);
+    }
+
+    @Test
+    @DisplayName("알림 횟수 제한 - 정해진 횟수까지만 알림을 보낼 수 있다")
+    void shouldAllowRequestsWithinLimit() {
+        // given
+        long fixedTime = 1000000000L; // 고정된 시간
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then
+        for (int i = 1; i <= AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result).isTrue();
+        }
+
+        boolean exceededResult = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(exceededResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("시간 구간별 독립 카운팅 - 시간이 지나면 알림 횟수가 초기화된다")
+    void shouldCountIndependentlyPerWindow() {
+        // given
+        long firstWindow = 1000000000L;   // 첫 번째 윈도우
+        long secondWindow = 1000060000L;  // 두 번째 윈도우 (1분 후)
+
+        // when: 첫 번째 윈도우에서 제한까지 사용
+        when(clock.millis()).thenReturn(firstWindow);
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        }
+        boolean firstWindowExceeded = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(firstWindowExceeded).isFalse();
+
+        // then: 새 윈도우에서는 다시 허용
+        when(clock.millis()).thenReturn(secondWindow);
+        boolean secondWindowAllowed = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(secondWindowAllowed).isTrue();
+    }
+
+    @Test
+    @DisplayName("시간 경계선 문제 - 시간 구간이 바뀌는 순간 예상보다 많은 알림이 허용된다")
+    void shouldDemonstrateBurstVulnerability() {
+        // given
+        long firstWindowTime = 1000020000L;   // 첫 번째 윈도우
+        long secondWindowTime = 1000080000L;  // 두 번째 윈도우 (60초 후)
+
+        // when: 첫 번째 윈도우 끝에서 최대치까지 요청
+        when(clock.millis()).thenReturn(firstWindowTime);
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result).isTrue();
+        }
+
+        // then: 새 윈도우에서 또 최대치까지 요청 가능
+        when(clock.millis()).thenReturn(secondWindowTime);
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("불공평한 처리 - 먼저 온 요청이 모든 할당량을 사용하면 나중 요청은 거부된다")
+    void shouldDemonstrateUnfairProcessing() {
+        // given
+        long windowStart = 1000080000L;     // 윈도우 시작
+        long windowMiddle = 1000110000L;    // 같은 윈도우 중간 (30초 후)
+
+        // 같은 윈도우인지 검증
+        long normalizedStart = (windowStart / 60000) * 60000;
+        long normalizedMiddle = (windowMiddle / 60000) * 60000;
+        assertThat(normalizedStart).isEqualTo(normalizedMiddle);
+
+        // when: 윈도우 시작 시점에 모든 할당량을 사용 (같은 errorCode 사용!)
+        when(clock.millis()).thenReturn(windowStart);
+        for (int i = 0; i < AlertLevel.INFO.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("SAME_ERROR", AlertLevel.INFO);
+            assertThat(result).isTrue(); // 초기 요청들은 허용되어야 함
+        }
+
+        // then: 같은 윈도우 내에서 나중에 온 요청은 거부됨
+        when(clock.millis()).thenReturn(windowMiddle);
+        boolean lateUserResult = rateLimiter.shouldSendAlert("SAME_ERROR", AlertLevel.INFO);
+        assertThat(lateUserResult).isFalse(); // 이제 실패해야 함
+    }
+
+    @Test
+    @DisplayName("알림 중요도별 제한 - 중요한 알림은 많이, 일반 알림은 적게 보낼 수 있다")
+    void shouldApplyDifferentLimitsPerAlertLevel() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: CRITICAL (10개)
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            assertThat(rateLimiter.shouldSendAlert("ERROR", AlertLevel.CRITICAL)).isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("ERROR", AlertLevel.CRITICAL)).isFalse();
+
+        // when & then: INFO (1개) - 다른 에러코드 사용
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("동시 접근 처리 - 여러 요청이 동시에 와도 정확한 개수만 허용된다")
+    void shouldHandleConcurrentRequests() throws InterruptedException {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        int threadCount = 20;
+        int requestsPerThread = 1;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        // when: 20개 스레드에서 동시에 요청
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < requestsPerThread; j++) {
+                        if (rateLimiter.shouldSendAlert("CONCURRENT_TEST", AlertLevel.CRITICAL)) {
+                            successCount.incrementAndGet();
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // then: CRITICAL_LIMIT(10)개만 허용되어야 함
+        assertThat(successCount.get()).isEqualTo(AlertLevel.CRITICAL.getAlertLimit());
+    }
+
+    @Test
+    @DisplayName("시간 정규화 - 같은 시간 구간의 다른 시점들이 올바르게 그룹핑된다")
+    void shouldNormalizeWindowCorrectly() {
+        // given - 다양한 시간 포인트들
+        long[] testTimes = {
+            1000000000L,  // 정확히 윈도우 시작
+            1000030000L,  // 윈도우 중간
+            1000059999L   // 윈도우 끝
+        };
+
+        // when & then
+        for (long testTime : testTimes) {
+            when(clock.millis()).thenReturn(testTime);
+            rateLimiter.shouldSendAlert("NORMALIZE_TEST", AlertLevel.INFO);
+        }
+
+        // 모든 요청이 같은 윈도우에서 카운팅되어 2번째부터는 거부되어야 함
+        when(clock.millis()).thenReturn(1000059999L);
+        boolean shouldReject = rateLimiter.shouldSendAlert("NORMALIZE_TEST", AlertLevel.INFO);
+        assertThat(shouldReject).isFalse();
+    }
+
+    @Test
+    @DisplayName("갑작스런 허용 현상 - 시간 구간이 바뀌면 갑자기 모든 요청이 허용된다")
+    void shouldDemonstrateResetPhenomenon() {
+        // given
+        long firstWindow = 1000000000L;
+        long secondWindow = 1000060000L; // 정확히 1분 후
+
+        // when: 첫 윈도우에서 제한까지 사용
+        when(clock.millis()).thenReturn(firstWindow);
+        for (int i = 0; i < AlertLevel.INFO.getAlertLimit(); i++) {
+            rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        }
+
+        // 제한 초과 확인
+        boolean exceededInFirstWindow = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(exceededInFirstWindow).isFalse();
+
+        // then: 새 윈도우에서는  모든 요청이 허용됨
+        when(clock.millis()).thenReturn(secondWindow);
+        boolean allowedInSecondWindow = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(allowedInSecondWindow).isTrue();
+    }
+
+    @Test
+    @DisplayName("오래된 데이터 정리 - 시간이 지난 알림 기록들을 자동으로 삭제한다")
+    void shouldCleanUpExpiredEntries() {
+        // given
+        long oldTime = 1000000000L;
+        long newTime = oldTime + (CLEANUP_LOOKBACK_MILLIS + 1000);
+
+        // when: 오래된 시간에 요청 생성
+        when(clock.millis()).thenReturn(oldTime);
+        rateLimiter.shouldSendAlert("OLD_REQUEST", AlertLevel.CRITICAL);
+
+        // then: cleanup 후에는 제거되어야 함
+        when(clock.millis()).thenReturn(newTime);
+        rateLimiter.cleanUpAlerts();
+
+        // cleanup 후 새 요청이 허용되는지 확인 (내부 맵이 정리되었다는 의미)
+        boolean newRequestAllowed = rateLimiter.shouldSendAlert("OLD_REQUEST", AlertLevel.CRITICAL);
+        assertThat(newRequestAllowed).isTrue();
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SlackMessageBuilderTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SlackMessageBuilderTest.java
@@ -1,6 +1,5 @@
 package com.eventitta.common.notification.service;
 
-import com.eventitta.common.notification.constants.AlertConstants;
 import com.eventitta.common.notification.domain.AlertLevel;
 import com.eventitta.common.notification.domain.SlackMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,12 +32,7 @@ class SlackMessageBuilderTest {
                 level, errorCode, body, null, null, null, "env", "#chan", "bot"
             );
             String expectedText = ":warning: " + level + " Alert";
-            String expectedColor = switch (level) {
-                case CRITICAL -> AlertConstants.CRITICAL_COLOR;
-                case HIGH -> AlertConstants.HIGH_COLOR;
-                case MEDIUM -> AlertConstants.MEDIUM_COLOR;
-                default -> AlertConstants.INFO_COLOR;
-            };
+            String expectedColor = level.getColor();
             assertThat(msg.text()).isEqualTo(expectedText);
             assertThat(msg.attachments()).hasSize(1);
             assertThat(msg.attachments().get(0).color()).isEqualTo(expectedColor);

--- a/src/test/java/com/eventitta/common/notification/service/SlidingWindowCounterRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SlidingWindowCounterRateLimiterTest.java
@@ -1,0 +1,321 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SlidingWindowCounterRateLimiterTest {
+
+    @Mock
+    private Clock clock;
+
+    private SlidingWindowCounterRateLimiter rateLimiter;
+
+    private static final long BUCKET_SIZE_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    private static final int NUM_BUCKETS = 5;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new SlidingWindowCounterRateLimiter(clock);
+        rateLimiter.reset();
+    }
+
+    @Test
+    @DisplayName("알림 횟수 제한 - 정해진 횟수까지만 알림을 보낼 수 있다")
+    void shouldAllowRequestsWithinLimit() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: 제한 내에서는 허용
+        for (int i = 1; i <= AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result)
+                .as("Request %d should be allowed", i)
+                .isTrue();
+        }
+
+        // 제한 초과시 거부
+        boolean exceededResult = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(exceededResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("버킷 단위 슬라이딩 - 새로운 버킷으로 이동하면서 오래된 버킷이 윈도우에서 제외된다")
+    void shouldSlideWindowByBuckets() {
+        // given
+        String uniqueErrorCode = "BUCKET_SLIDE_TEST_" + System.nanoTime();
+        long startTime = 1000000000L;
+        long nextBucket = startTime + BUCKET_SIZE_MILLIS; // 다음 버킷 (1분 후)
+        long afterFiveBuckets = startTime + (NUM_BUCKETS * BUCKET_SIZE_MILLIS); // 5분 후
+
+        // when: 첫 버킷에서 제한까지 사용
+        when(clock.millis()).thenReturn(startTime);
+        boolean firstRequest = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(firstRequest).isTrue();
+
+        // 같은 버킷에서 초과
+        boolean exceededInSameBucket = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(exceededInSameBucket).isFalse();
+
+        // 다음 버킷으로 이동해도 여전히 윈도우 내에 있으므로 제한
+        when(clock.millis()).thenReturn(nextBucket);
+        boolean stillBlocked = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(stillBlocked).isFalse();
+
+        // then: 5분 후 첫 버킷이 윈도우에서 벗어나면 다시 허용
+        when(clock.millis()).thenReturn(afterFiveBuckets);
+        boolean allowedAfterWindow = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(allowedAfterWindow).isTrue();
+    }
+
+    @Test
+    @DisplayName("버킷 경계 처리 - 버킷 경계에서 정확한 카운팅")
+    void shouldHandleBucketBoundaries() {
+        // given
+        long bucketStart = (1000000000L / BUCKET_SIZE_MILLIS) * BUCKET_SIZE_MILLIS;
+        long justBeforeBoundary = bucketStart + BUCKET_SIZE_MILLIS - 1; // 버킷 끝
+        long justAfterBoundary = bucketStart + BUCKET_SIZE_MILLIS; // 다음 버킷 시작
+        String uniqueErrorCode = "BOUNDARY_TEST_" + System.nanoTime();
+
+        // when: 버킷 끝에서 요청
+        when(clock.millis()).thenReturn(justBeforeBoundary);
+        boolean firstInBucket = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(firstInBucket).isTrue();
+
+        // 같은 버킷에서 두 번째 요청은 거부
+        boolean secondInSameBucket = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(secondInSameBucket).isFalse();
+
+        // then: 다음 버킷 시작에서는 여전히 전체 윈도우 카운트 때문에 거부
+        when(clock.millis()).thenReturn(justAfterBoundary);
+        boolean firstInNextBucket = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(firstInNextBucket).isFalse(); // 5분 윈도우 내 총 2개가 되므로 거부
+    }
+
+    @Test
+    @DisplayName("다중 버킷 누적 - 여러 버킷에 걸쳐 요청이 누적되어 계산된다")
+    void shouldAccumulateAcrossMultipleBuckets() {
+        // given
+        String uniqueErrorCode = "MULTI_BUCKET_" + System.nanoTime();
+        long startTime = 1000000000L;
+
+        // when: MEDIUM (제한 2개)를 여러 버킷에 걸쳐 사용
+        // 첫 번째 버킷에서 1개
+        when(clock.millis()).thenReturn(startTime);
+        boolean first = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(first).isTrue();
+
+        // 두 번째 버킷에서 1개
+        when(clock.millis()).thenReturn(startTime + BUCKET_SIZE_MILLIS);
+        boolean second = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(second).isTrue();
+
+        // 세 번째 버킷에서 시도하면 거부 (윈도우 내 총 2개)
+        when(clock.millis()).thenReturn(startTime + (2 * BUCKET_SIZE_MILLIS));
+        boolean third = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(third).isFalse();
+    }
+
+    @Test
+    @DisplayName("알림 중요도별 제한 - 중요한 알림은 많이, 일반 알림은 적게 보낼 수 있다")
+    void shouldApplyDifferentLimitsPerAlertLevel() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: CRITICAL (10개)
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            assertThat(rateLimiter.shouldSendAlert("CRITICAL_ERROR", AlertLevel.CRITICAL))
+                .isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("CRITICAL_ERROR", AlertLevel.CRITICAL)).isFalse();
+
+        // HIGH (5개)
+        for (int i = 0; i < AlertLevel.HIGH.getAlertLimit(); i++) {
+            assertThat(rateLimiter.shouldSendAlert("HIGH_ERROR", AlertLevel.HIGH))
+                .isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("HIGH_ERROR", AlertLevel.HIGH)).isFalse();
+
+        // INFO (1개)
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("에러 코드별 독립 카운팅 - 다른 에러는 각각 별도로 제한이 적용된다")
+    void shouldCountIndependentlyPerErrorCode() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: 첫 번째 에러코드로 제한까지 사용
+        rateLimiter.shouldSendAlert("ERROR_A", AlertLevel.INFO);
+        boolean firstErrorExceeded = rateLimiter.shouldSendAlert("ERROR_A", AlertLevel.INFO);
+        assertThat(firstErrorExceeded).isFalse();
+
+        // 두 번째 에러코드는 여전히 허용
+        boolean secondErrorAllowed = rateLimiter.shouldSendAlert("ERROR_B", AlertLevel.INFO);
+        assertThat(secondErrorAllowed).isTrue();
+    }
+
+    @Test
+    @DisplayName("동시 접근 처리 - 여러 요청이 동시에 와도 정확한 개수만 허용된다")
+    void shouldHandleConcurrentRequests() throws InterruptedException {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        String uniqueErrorCode = "CONCURRENT_TEST_" + System.nanoTime();
+
+        // when: 20개 스레드에서 동시에 요청
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    if (rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.CRITICAL)) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // then: CRITICAL_LIMIT(10)개만 허용되어야 함
+        assertThat(successCount.get()).isEqualTo(AlertLevel.CRITICAL.getAlertLimit());
+    }
+
+    @Test
+    @DisplayName("윈도우 슬라이딩 시뮬레이션 - 5개 버킷 윈도우")
+    void shouldSimulateWindowSliding() {
+        // given
+        String uniqueErrorCode = "SLIDING_SIM_" + System.nanoTime();
+        long baseTime = (1000000000L / BUCKET_SIZE_MILLIS) * BUCKET_SIZE_MILLIS;
+
+        // when: 매 분마다 1개씩 요청 (INFO는 5분 윈도우에 1개만 허용)
+        for (int minute = 0; minute < 10; minute++) {
+            long currentTime = baseTime + (minute * BUCKET_SIZE_MILLIS);
+            when(clock.millis()).thenReturn(currentTime);
+
+            boolean result = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+
+            if (minute == 0) {
+                assertThat(result)
+                    .isTrue();
+            } else if (minute < 5) {
+                assertThat(result)
+                    .isFalse();
+            } else if (minute == 5) {
+                assertThat(result)
+                    .isTrue();
+                break;
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("scheduledCleanup 테스트 - 오래된 버킷 데이터 정리")
+    void shouldCleanupOldBuckets() {
+        // given
+        long startTime = 1000000000L;
+        long oldTime = startTime - (10 * BUCKET_SIZE_MILLIS); // 10분 전
+
+        // when: 오래된 시간과 최근 시간에 요청
+        when(clock.millis()).thenReturn(oldTime);
+        rateLimiter.shouldSendAlert("OLD_ERROR", AlertLevel.INFO);
+
+        when(clock.millis()).thenReturn(startTime);
+        rateLimiter.shouldSendAlert("RECENT_ERROR", AlertLevel.INFO);
+
+        // cleanup 실행
+        when(clock.millis()).thenReturn(startTime);
+        rateLimiter.scheduledCleanup();
+
+        // then: 최근 요청은 유지, 오래된 요청은 정리되어 새 요청 허용
+        when(clock.millis()).thenReturn(startTime);
+        boolean recentStillBlocked = rateLimiter.shouldSendAlert("RECENT_ERROR", AlertLevel.INFO);
+        assertThat(recentStillBlocked).isFalse(); // 여전히 제한
+
+        // 오래된 에러는 정리되어 있어야 하지만, 새로운 버킷에서는 허용
+        when(clock.millis()).thenReturn(startTime);
+        boolean oldAllowed = rateLimiter.shouldSendAlert("OLD_ERROR", AlertLevel.INFO);
+        assertThat(oldAllowed).isTrue(); // 오래된 데이터 정리되어 허용
+    }
+
+    @Test
+    @DisplayName("리셋 기능 - 모든 알림 기록을 초기화할 수 있다")
+    void shouldResetAllAlerts() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when: 제한까지 사용
+        rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        boolean beforeReset = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(beforeReset).isFalse();
+
+        // reset 후
+        rateLimiter.reset();
+
+        // then: 다시 허용됨
+        boolean afterReset = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(afterReset).isTrue();
+    }
+
+    @Test
+    @DisplayName("복합 시나리오 - 여러 에러 코드와 레벨이 섞인 실제 상황을 시뮬레이션한다")
+    void shouldHandleComplexScenario() {
+        // given
+        long startTime = 1000000000L;
+        when(clock.millis()).thenReturn(startTime);
+
+        // when: 다양한 알림 레벨과 에러 코드로 요청
+        for (int i = 0; i < 3; i++) {
+            assertThat(rateLimiter.shouldSendAlert("DB_ERROR", AlertLevel.CRITICAL)).isTrue();
+        }
+
+        // 버킷 2: Payment 에러
+        when(clock.millis()).thenReturn(startTime + BUCKET_SIZE_MILLIS);
+        for (int i = 0; i < 2; i++) {
+            assertThat(rateLimiter.shouldSendAlert("PAYMENT_ERROR", AlertLevel.HIGH)).isTrue();
+        }
+
+        // 버킷 3: 다양한 에러
+        when(clock.millis()).thenReturn(startTime + (2 * BUCKET_SIZE_MILLIS));
+        assertThat(rateLimiter.shouldSendAlert("DB_ERROR", AlertLevel.CRITICAL)).isTrue(); // 4/10
+        assertThat(rateLimiter.shouldSendAlert("PAYMENT_ERROR", AlertLevel.HIGH)).isTrue(); // 3/5
+        assertThat(rateLimiter.shouldSendAlert("USER_LOGIN", AlertLevel.INFO)).isTrue(); // 1/1
+
+        // then: 각 제한 확인
+        assertThat(rateLimiter.shouldSendAlert("USER_LOGIN", AlertLevel.INFO)).isFalse(); // INFO 초과
+
+        // DB는 아직 여유 있음 (4/10)
+        for (int i = 0; i < 6; i++) {
+            assertThat(rateLimiter.shouldSendAlert("DB_ERROR", AlertLevel.CRITICAL)).isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("DB_ERROR", AlertLevel.CRITICAL)).isFalse(); // 이제 초과
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/SlidingWindowLogRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/SlidingWindowLogRateLimiterTest.java
@@ -1,0 +1,305 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SlidingWindowLogRateLimiterTest {
+
+    @Mock
+    private Clock clock;
+
+    private SlidingWindowLogRateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new SlidingWindowLogRateLimiter(clock);
+        rateLimiter.reset();
+    }
+
+    @Test
+    @DisplayName("알림 횟수 제한 - 정해진 횟수까지만 알림을 보낼 수 있다")
+    void shouldAllowRequestsWithinLimit() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: 제한 내에서는 허용
+        for (int i = 1; i <= AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result).isTrue();
+        }
+
+        // 제한 초과시 거부
+        boolean exceededResult = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(exceededResult).isFalse();
+    }
+
+    @Test
+    @DisplayName("시간 윈도우 슬라이딩 - 오래된 요청은 자동으로 만료되어 새 요청이 허용된다")
+    void shouldSlideWindowAndAllowNewRequests() {
+        // given
+        String uniqueErrorCode = "SLIDE_TEST_" + System.nanoTime();
+        long startTime = 1000000000L;
+        long afterWindow = startTime + (5 * 60 * 1000) + 1;
+
+        // when: 초기 시간에 제한까지 사용
+        when(clock.millis()).thenReturn(startTime);
+        boolean firstRequest = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(firstRequest).isTrue();
+
+        // 제한 초과 확인
+        boolean exceededAtStart = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(exceededAtStart).isFalse();
+
+        // then: 5분 후에는 다시 허용
+        when(clock.millis()).thenReturn(afterWindow);
+        boolean allowedAfterSlide = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(allowedAfterSlide).isTrue();
+    }
+
+    @Test
+    @DisplayName("부분적 윈도우 슬라이딩 - 일부 요청만 만료되어 정확한 개수만큼 허용된다")
+    void shouldPartiallySlideWindow() {
+        // given
+        String uniqueErrorCode = "PARTIAL_TEST_" + System.nanoTime();
+        long startTime = 1000000000L;
+        long halfWindow = startTime + (2 * 60 * 1000) + (30 * 1000); // 2분 30초 후
+        long afterFullWindow = startTime + (5 * 60 * 1000) + 1; // 5분 1밀리초 후
+
+        // when: 초기에 2개 요청 (MEDIUM 레벨, 제한 2개)
+        when(clock.millis()).thenReturn(startTime);
+        boolean first = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(first).isTrue();
+        boolean second = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(second).isTrue();
+
+        // 2분 30초 후에 1개 더 요청 (총 3개, 제한 초과)
+        when(clock.millis()).thenReturn(halfWindow);
+        boolean exceededAtHalf = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(exceededAtHalf).isFalse();
+
+        // then: 5분 1밀리초 후에는 초기 요청들이 만료되어 새 요청 허용
+        when(clock.millis()).thenReturn(afterFullWindow);
+        boolean allowedAfterWindow = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(allowedAfterWindow).isTrue();
+    }
+
+    @Test
+    @DisplayName("정확한 윈도우 경계 처리 - 정확히 5분 경계에서의 동작")
+    void shouldHandleExactWindowBoundary() {
+        // given
+        long startTime = 1000000000L;
+        long exactWindow = startTime + (5 * 60 * 1000); // 정확히 5분 후
+        String uniqueErrorCode = "BOUNDARY_TEST_" + System.nanoTime();
+
+        // when: 첫 번째 요청
+        when(clock.millis()).thenReturn(startTime);
+        boolean first = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(first).isTrue();
+
+        // then: 정확히 5분 후에는 이전 타임스탬프가 제거되어 허용됨 (<= 조건)
+        when(clock.millis()).thenReturn(exactWindow);
+        boolean allowedAtBoundary = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(allowedAtBoundary).isTrue(); // <= 조건이므로 경계에서 제거되어 허용
+    }
+
+    @Test
+    @DisplayName("알림 중요도별 제한 - 중요한 알림은 많이, 일반 알림은 적게 보낼 수 있다")
+    void shouldApplyDifferentLimitsPerAlertLevel() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: CRITICAL (10개)
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+            assertThat(result).isTrue();
+        }
+
+        // 제한 초과시 거부
+        boolean exceededResult = rateLimiter.shouldSendAlert("ERROR_001", AlertLevel.CRITICAL);
+        assertThat(exceededResult).isFalse();
+
+        // when & then: INFO (1개)
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("INFO_ERROR", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("에러 코드별 독립 카운팅 - 다른 에러는 각각 별도로 제한이 적용된다")
+    void shouldCountIndependentlyPerErrorCode() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when & then: 첫 번째 에러코드로 제한까지 사용
+        rateLimiter.shouldSendAlert("ERROR_A", AlertLevel.INFO);
+        boolean firstErrorExceeded = rateLimiter.shouldSendAlert("ERROR_A", AlertLevel.INFO);
+        assertThat(firstErrorExceeded).isFalse();
+
+        // 두 번째 에러코드는 여전히 허용
+        boolean secondErrorAllowed = rateLimiter.shouldSendAlert("ERROR_B", AlertLevel.INFO);
+        assertThat(secondErrorAllowed).isTrue();
+    }
+
+    @Test
+    @DisplayName("동시 접근 처리 - 여러 요청이 동시에 와도 정확한 개수만 허용된다")
+    void shouldHandleConcurrentRequests() throws InterruptedException {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        int threadCount = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        // when: 20개 스레드에서 동시에 요청
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    if (rateLimiter.shouldSendAlert("CONCURRENT_TEST", AlertLevel.CRITICAL)) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // then: CRITICAL_LIMIT(10)개만 허용되어야 함
+        assertThat(successCount.get()).isEqualTo(AlertLevel.CRITICAL.getAlertLimit());
+    }
+
+    @Test
+    @DisplayName("연속적인 윈도우 슬라이딩 - 시간이 계속 지나면서 요청이 지속적으로 허용된다")
+    void shouldContinuouslySlideWindow() {
+        // given
+        String uniqueErrorCode = "CONTINUOUS_TEST_" + System.nanoTime();
+        long startTime = 1000000000L;
+
+        // when: 초기 요청
+        when(clock.millis()).thenReturn(startTime);
+        boolean firstAllowed = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(firstAllowed).isTrue();
+
+        // 제한 확인
+        boolean secondBlocked = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+        assertThat(secondBlocked).isFalse();
+
+        // then: 매 5분마다 새로운 요청이 허용됨
+        for (int interval = 1; interval <= 3; interval++) {
+            long timeAfterIntervals = startTime + (interval * 5 * 60 * 1000) + 1; // 5분 간격 + 1ms
+            when(clock.millis()).thenReturn(timeAfterIntervals);
+
+            boolean allowed = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+            assertThat(allowed).isTrue();
+
+            // 바로 다음 요청은 거부되어야 함
+            boolean blocked = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.INFO);
+            assertThat(blocked).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("복합 시나리오 - 여러 에러 코드와 레벨이 섞인 실제 상황을 시뮬레이션한다")
+    void shouldHandleComplexScenario() {
+        // given
+        long startTime = 1000000000L;
+        when(clock.millis()).thenReturn(startTime);
+
+        // when: 다양한 알림 레벨과 에러 코드로 요청
+        // CRITICAL 에러 5개
+        for (int i = 0; i < 5; i++) {
+            assertThat(rateLimiter.shouldSendAlert("DB_CONNECTION_FAILED", AlertLevel.CRITICAL)).isTrue();
+        }
+
+        // HIGH 에러 3개
+        for (int i = 0; i < 3; i++) {
+            assertThat(rateLimiter.shouldSendAlert("PAYMENT_FAILED", AlertLevel.HIGH)).isTrue();
+        }
+
+        // INFO 에러 1개
+        assertThat(rateLimiter.shouldSendAlert("USER_LOGIN", AlertLevel.INFO)).isTrue();
+
+        // then: 각 레벨별로 추가 요청 제한 확인
+        // CRITICAL은 5개 더 허용 (총 10개)
+        for (int i = 0; i < 5; i++) {
+            assertThat(rateLimiter.shouldSendAlert("DB_CONNECTION_FAILED", AlertLevel.CRITICAL)).isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("DB_CONNECTION_FAILED", AlertLevel.CRITICAL)).isFalse();
+
+        // HIGH는 2개 더 허용 (총 5개)
+        for (int i = 0; i < 2; i++) {
+            assertThat(rateLimiter.shouldSendAlert("PAYMENT_FAILED", AlertLevel.HIGH)).isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert("PAYMENT_FAILED", AlertLevel.HIGH)).isFalse();
+
+        // INFO는 이미 제한 도달
+        assertThat(rateLimiter.shouldSendAlert("USER_LOGIN", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("메모리 효율성 - 시간이 지나면서 오래된 타임스탬프가 정리된다")
+    void shouldCleanUpOldTimestamps() {
+        // given
+        String uniqueErrorCode = "CLEANUP_TEST_" + System.nanoTime();
+        long startTime = 1000000000L;
+        long afterWindow = startTime + (5 * 60 * 1000) + 1; // 5분 1밀리초 후
+
+        // when: 여러 요청으로 타임스탬프 생성
+        when(clock.millis()).thenReturn(startTime);
+        for (int i = 0; i < AlertLevel.MEDIUM.getAlertLimit(); i++) {
+            boolean result = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+            assertThat(result).isTrue();
+        }
+
+        // then: 윈도우 이후 새 요청시 오래된 타임스탬프가 정리되고 새 요청 허용
+        when(clock.millis()).thenReturn(afterWindow);
+        boolean cleanedAndAllowed = rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM);
+        assertThat(cleanedAndAllowed).isTrue();
+
+        // 제한까지 다시 채울 수 있음 (이전 타임스탬프들이 정리되었다는 증거)
+        for (int i = 1; i < AlertLevel.MEDIUM.getAlertLimit(); i++) {
+            assertThat(rateLimiter.shouldSendAlert(uniqueErrorCode, AlertLevel.MEDIUM)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("리셋 기능 - 모든 알림 기록을 초기화할 수 있다")
+    void shouldResetAllAlerts() {
+        // given
+        long fixedTime = 1000000000L;
+        when(clock.millis()).thenReturn(fixedTime);
+
+        // when: 제한까지 사용
+        rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        boolean beforeReset = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(beforeReset).isFalse();
+
+        // reset 후
+        rateLimiter.reset();
+
+        // then: 다시 허용됨
+        boolean afterReset = rateLimiter.shouldSendAlert("RESET_TEST", AlertLevel.INFO);
+        assertThat(afterReset).isTrue();
+    }
+}

--- a/src/test/java/com/eventitta/common/notification/service/TokenBucketRateLimiterTest.java
+++ b/src/test/java/com/eventitta/common/notification/service/TokenBucketRateLimiterTest.java
@@ -1,0 +1,312 @@
+package com.eventitta.common.notification.service;
+
+import com.eventitta.common.notification.domain.AlertLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenBucketRateLimiterTest {
+
+    private TokenBucketRateLimiter rateLimiter;
+    private Clock mockClock;
+    private long currentTimeMillis;
+
+    @BeforeEach
+    void setUp() {
+        mockClock = mock(Clock.class);
+        currentTimeMillis = System.currentTimeMillis();
+        when(mockClock.millis()).thenReturn(currentTimeMillis);
+        rateLimiter = new TokenBucketRateLimiter(mockClock);
+    }
+
+    @Test
+    @DisplayName("처음 요청 시 모든 AlertLevel에 대해 알림 허용")
+    void shouldAllowFirstAlert() {
+        // given
+        String errorCode = "ERROR_001";
+
+        // when & then
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.CRITICAL)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.HIGH)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.MEDIUM)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.INFO)).isTrue();
+    }
+
+    @Test
+    @DisplayName("CRITICAL 레벨 토큰 소모 및 충전 확인 (10개 제한)")
+    void shouldManageCriticalLevelTokens() {
+        // given
+        String errorCode = "CRITICAL_ERROR";
+        AlertLevel level = AlertLevel.CRITICAL;
+
+        // when: 최대 허용량까지 요청
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        }
+
+        // then: 추가 요청은 거부
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+
+    @Test
+    @DisplayName("시간 경과에 따른 토큰 충전 확인")
+    void shouldRefillTokensOverTime() {
+        // given
+        String errorCode = "TIME_TEST";
+        AlertLevel level = AlertLevel.HIGH;
+
+        // when: 모든 토큰 소모
+        for (int i = 0; i < AlertLevel.HIGH.getAlertLimit(); i++) {
+            rateLimiter.shouldSendAlert(errorCode, level);
+        }
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+
+        // 1분 경과 시뮬레이션 (5개 용량, 5분 주기 = 1개/분)
+        long oneMinuteLater = currentTimeMillis + TimeUnit.MINUTES.toMillis(1);
+        when(mockClock.millis()).thenReturn(oneMinuteLater);
+
+        // then: 토큰이 충전되어 요청 허용
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level))
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("각 AlertLevel별 정확한 제한값 확인")
+    void shouldRespectExactLimitsForEachLevel() {
+        String errorCode = "LIMIT_TEST";
+
+        // CRITICAL: 10개
+        testExactLimit(errorCode, AlertLevel.CRITICAL, AlertLevel.CRITICAL.getAlertLimit());
+
+        // HIGH: 5개
+        testExactLimit(errorCode + "_HIGH", AlertLevel.HIGH, AlertLevel.HIGH.getAlertLimit());
+
+        // MEDIUM: 2개
+        testExactLimit(errorCode + "_MEDIUM", AlertLevel.MEDIUM, AlertLevel.MEDIUM.getAlertLimit());
+
+        // INFO: 1개
+        testExactLimit(errorCode + "_INFO", AlertLevel.INFO, AlertLevel.INFO.getAlertLimit());
+    }
+
+    private void testExactLimit(String errorCode, AlertLevel level, int expectedLimit) {
+        // 정확히 제한값까지 허용
+        for (int i = 0; i < expectedLimit; i++) {
+            assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        }
+
+        // 제한값 초과 시 거부
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+
+    @Test
+    @DisplayName("동일한 errorCode, 다른 AlertLevel은 독립적으로 관리")
+    void shouldManageIndependentlyByErrorCodeAndLevel() {
+        // given
+        String errorCode = "SAME_ERROR";
+
+        // when: 같은 errorCode로 다른 레벨 요청
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.CRITICAL)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.HIGH)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.MEDIUM)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.INFO)).isTrue();
+
+        // then: 각각 독립적으로 관리되어야 함
+        // INFO 제한 도달 후에도 다른 레벨은 영향받지 않음
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.INFO)).isFalse();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, AlertLevel.MEDIUM)).isTrue();
+    }
+
+    @Test
+    @DisplayName("매우 긴 시간 경과 후 토큰이 최대값을 초과하지 않음")
+    void shouldNotExceedMaxCapacityAfterLongTime() {
+        // given
+        String errorCode = "LONG_TIME_TEST";
+        AlertLevel level = AlertLevel.MEDIUM;
+
+        // when: 매우 긴 시간 경과 (10시간)
+        long tenHoursLater = currentTimeMillis + TimeUnit.HOURS.toMillis(10);
+        when(mockClock.millis()).thenReturn(tenHoursLater);
+
+        // then: 최대 용량만큼만 사용 가능 (2개)
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+
+    @Test
+    @DisplayName("시간이 역행해도 토큰이 음수가 되지 않음")
+    void shouldHandleTimeGoingBackwards() {
+        // given
+        String errorCode = "TIME_BACKWARDS";
+        AlertLevel level = AlertLevel.INFO;
+
+        // 토큰 소모
+        rateLimiter.shouldSendAlert(errorCode, level);
+
+        // when: 시간이 과거로 돌아감
+        long pastTime = currentTimeMillis - TimeUnit.MINUTES.toMillis(5);
+        when(mockClock.millis()).thenReturn(pastTime);
+
+        // then: 추가 토큰 충전 없이 거부되어야 함
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+
+    @Test
+    @DisplayName("null errorCode 처리 - null도 유효한 키로 처리됨")
+    void shouldHandleNullErrorCode() {
+        // when & then: null도 문자열로 변환되어 처리됨
+        assertThat(rateLimiter.shouldSendAlert(null, AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(null, AlertLevel.INFO)).isFalse(); // INFO는 1개 제한
+    }
+
+    @Test
+    @DisplayName("null AlertLevel 처리")
+    void shouldHandleNullAlertLevel() {
+        // when & then
+        assertThatThrownBy(() -> rateLimiter.shouldSendAlert("ERROR", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 errorCode 처리")
+    void shouldHandleEmptyErrorCode() {
+        // when & then: 빈 문자열도 유효한 키로 처리되어야 함
+        assertThat(rateLimiter.shouldSendAlert("", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("공백 문자열 errorCode 처리")
+    void shouldHandleWhitespaceErrorCode() {
+        // when & then
+        assertThat(rateLimiter.shouldSendAlert("   ", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("   ", AlertLevel.INFO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("동일한 키에 대한 동시 요청 처리")
+    void shouldHandleConcurrentRequestsForSameKey() throws InterruptedException {
+        // given
+        String errorCode = "CONCURRENT_TEST";
+        AlertLevel level = AlertLevel.MEDIUM; // 2개 제한
+        int threadCount = 10;
+        Thread[] threads = new Thread[threadCount];
+        boolean[] results = new boolean[threadCount];
+
+        // when: 여러 스레드가 동시에 요청
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            threads[i] = new Thread(() -> results[index] = rateLimiter.shouldSendAlert(errorCode, level));
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // then: 정확히 2개만 허용되어야 함
+        long allowedCount = 0;
+        for (boolean result : results) {
+            if (result) allowedCount++;
+        }
+        assertThat(allowedCount).isEqualTo(AlertLevel.MEDIUM.getAlertLimit());
+    }
+
+    @Test
+    @DisplayName("reset 후 모든 제한이 초기화됨")
+    void shouldClearAllLimitsAfterReset() {
+        // given: 여러 키에 대해 제한 도달
+        rateLimiter.shouldSendAlert("ERROR1", AlertLevel.INFO);
+        rateLimiter.shouldSendAlert("ERROR2", AlertLevel.MEDIUM);
+        rateLimiter.shouldSendAlert("ERROR2", AlertLevel.MEDIUM);
+
+        // 제한 확인
+        assertThat(rateLimiter.shouldSendAlert("ERROR1", AlertLevel.INFO)).isFalse();
+        assertThat(rateLimiter.shouldSendAlert("ERROR2", AlertLevel.MEDIUM)).isFalse();
+
+        // when: 리셋
+        rateLimiter.reset();
+
+        // then: 모든 제한이 초기화됨
+        assertThat(rateLimiter.shouldSendAlert("ERROR1", AlertLevel.INFO)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert("ERROR2", AlertLevel.MEDIUM)).isTrue();
+    }
+
+    @Test
+    @DisplayName("빈 상태에서 reset 호출해도 문제없음")
+    void shouldHandleResetOnEmptyState() {
+        // when & then: 예외가 발생하지 않아야 함
+        rateLimiter.reset();
+
+        // 정상 동작 확인
+        assertThat(rateLimiter.shouldSendAlert("TEST", AlertLevel.INFO)).isTrue();
+    }
+
+    @Test
+    @DisplayName("정확한 충전률로 토큰이 충전됨 (HIGH 레벨: 5개/5분 = 1개/분)")
+    void shouldRefillAtCorrectRate() {
+        // given
+        String errorCode = "REFILL_TEST";
+        AlertLevel level = AlertLevel.HIGH; // 5개 제한, 5분 주기
+
+        // 모든 토큰 소모
+        for (int i = 0; i < AlertLevel.HIGH.getAlertLimit(); i++) {
+            rateLimiter.shouldSendAlert(errorCode, level);
+        }
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+
+        // when: 30초 경과 (0.5분)
+        long thirtySecondsLater = currentTimeMillis + TimeUnit.SECONDS.toMillis(30);
+        when(mockClock.millis()).thenReturn(thirtySecondsLater);
+
+        // then: 아직 토큰이 충전되지 않아야 함 (1분 단위로 충전)
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+
+        // when: 1분 경과
+        long oneMinuteLater = currentTimeMillis + TimeUnit.MINUTES.toMillis(1);
+        when(mockClock.millis()).thenReturn(oneMinuteLater);
+
+        // then: 1개 토큰이 충전되어야 함
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isTrue();
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+
+    @Test
+    @DisplayName("부분적 시간 경과에 대한 토큰 충전")
+    void shouldHandlePartialTimeRefill() {
+        // given
+        String errorCode = "PARTIAL_REFILL";
+        AlertLevel level = AlertLevel.CRITICAL;
+
+        // 모든 토큰 소모
+        for (int i = 0; i < AlertLevel.CRITICAL.getAlertLimit(); i++) {
+            rateLimiter.shouldSendAlert(errorCode, level);
+        }
+
+        // when: 2.5분 경과 (5개 토큰 충전 예상)
+        long twoAndHalfMinutes = currentTimeMillis + TimeUnit.SECONDS.toMillis(150);
+        when(mockClock.millis()).thenReturn(twoAndHalfMinutes);
+
+        // then: 5개 토큰이 충전되어야 함
+        for (int i = 0; i < 5; i++) {
+            assertThat(rateLimiter.shouldSendAlert(errorCode, level))
+                .as("%d번째 토큰은 사용 가능해야 함", i + 1)
+                .isTrue();
+        }
+        assertThat(rateLimiter.shouldSendAlert(errorCode, level)).isFalse();
+    }
+}


### PR DESCRIPTION
This pull request refactors alert level configuration and rate limiter implementations to improve maintainability and extensibility. Alert limit and color settings for each alert level are now encapsulated within the `AlertLevel` enum, removing hard-coded values from `AlertConstants`. Additionally, several new rate limiter strategies have been introduced, each as a separate class, and common logic has been moved to the `RateLimiter` interface. 

**Alert Level Configuration Refactor:**
* Moved alert limit and color settings from `AlertConstants` to new fields and methods in the `AlertLevel` enum, allowing direct access via `level.getAlertLimit()` and `level.getColor()`. (`AlertLevel.java`, `AlertConstants.java`) [[1]](diffhunk://#diff-403ba745e59e8ac3ffa37150ba66ec764b34c0a813012c00c5dc1c3304e1e618L4-R23) [[2]](diffhunk://#diff-02edb040b52e5bdd5b72e3e0c307362f23dc93004420c6220167413e19085dd8L7-L18)
* Updated usages throughout the codebase to utilize these new enum methods instead of constants. (`SlackMessageBuilder.java`, `RateLimiter.java`, and all rate limiter implementations) [[1]](diffhunk://#diff-6857bb6d69b13be72a9a003d3bdc23de55828e2a0ad139c7ec5529b48bc5a192L83-R83) [[2]](diffhunk://#diff-becd41a370c98998702344d098818c361b76d6a6a44744617c81bdb4fcf295d1R7-R16)

**Rate Limiter Strategy Expansion:**
* Added four new rate limiter implementations: `FixedWindowRateLimiter`, `SlidingWindowCounterRateLimiter`, `SlidingWindowLogRateLimiter`, and `TokenBucketRateLimiter`, each encapsulating a different algorithm for rate limiting alerts. (`FixedWindowRateLimiter.java`, `SlidingWindowCounterRateLimiter.java`, `SlidingWindowLogRateLimiter.java`, `TokenBucketRateLimiter.java`) [[1]](diffhunk://#diff-06218fb9182a0268ae8a2f72a24fa5635b4bd8f1f128babab73630a077662f94R1-R60) [[2]](diffhunk://#diff-c69e6be4bdef1fa9e0adcb8c20bcddc517104ef2628a3b8eed163a15e7795b47R1-R84) [[3]](diffhunk://#diff-4dd1b7135ae2cadd015a43a556c75540a29426111a6449a5cfcd97e33b2e3f07R1-R40) [[4]](diffhunk://#diff-3976135bb55d6b1842c2f8a2f0538556a907f4f9ea2803e0b70f3fbdc2fac0e3R1-R53)
* Refactored existing rate limiter classes (`CacheBasedRateLimiter`, `SimpleRateLimiter`) to remove redundant logic for alert limit and color retrieval, and to use the new enum methods. [[1]](diffhunk://#diff-95f4e585c20cd11c09d5a63f26199803f140bdf164df38bd3e3074e20bf4da53L10-L27) [[2]](diffhunk://#diff-95f4e585c20cd11c09d5a63f26199803f140bdf164df38bd3e3074e20bf4da53L50-L62) [[3]](diffhunk://#diff-f0964072a9b2671507a3a9aeedbc6d42d2ab82655079f856001401f4b60f7edeL15-L16) [[4]](diffhunk://#diff-f0964072a9b2671507a3a9aeedbc6d42d2ab82655079f856001401f4b60f7edeL50-L68)

**Benchmark and Test Updates:**
* Updated the benchmark class `CacheBasedRateLimiterBenchmark` to remove the use of a fixed clock and adapt to the refactored rate limiter constructor. [[1]](diffhunk://#diff-bcf3bc37a2e9fa693106c5f52c2ee2dd08c5e0550339ad6f240cc92614c22100L7-L9) [[2]](diffhunk://#diff-bcf3bc37a2e9fa693106c5f52c2ee2dd08c5e0550339ad6f240cc92614c22100L24) [[3]](diffhunk://#diff-bcf3bc37a2e9fa693106c5f52c2ee2dd08c5e0550339ad6f240cc92614c22100L34-R30)
* Improved test descriptions in `AlertLevelResolverTest` for clarity and to align with new error message handling.