### PR TITLE
chore: Dockerfile에서 jdk 이미지 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY gradlew .
 RUN chmod +x gradlew
 RUN ./gradlew clean bootJar --no-daemon --warning-mode=none
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` for building and running the application. The change shifts from using the Alpine variant of the Eclipse Temurin JRE to the standard version, which can improve compatibility and resolve issues related to native dependencies.

Docker image update:

* Changed the base image from `eclipse-temurin:17-jre-alpine` to `eclipse-temurin:17-jre` in the `Dockerfile` to use the standard JRE instead of the Alpine variant.