### PR TITLE
chore: Dockerfile에서 jdk 이미지 교체

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@ node_modules/
 .gitignore
 **/*.log
 **/*.sock
+.idea
+.gradle
+*.imls

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY gradlew .
 RUN chmod +x gradlew
 RUN ./gradlew clean bootJar --no-daemon --warning-mode=none
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-# syntax=docker/dockerfile:1
 FROM gradle:8.13-jdk17 AS build
 WORKDIR /app
 
+COPY build.gradle settings.gradle gradle.properties ./
 COPY gradle/ gradle/
-COPY gradlew .
-COPY gradlew.bat .
-COPY build.gradle .
-COPY settings.gradle .
-COPY gradle.properties .
-RUN chmod +x ./gradlew
+RUN ./gradlew dependencies --no-daemon || true
 
 COPY src/ src/
+COPY gradlew .
+RUN chmod +x gradlew
 RUN ./gradlew clean bootJar --no-daemon --warning-mode=none
 
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar /app/app.jar
+COPY --from=build /app/build/libs/*.jar app.jar
+
 EXPOSE 8080
-ENV SPRING_PROFILES_ACTIVE=docker
 ENTRYPOINT ["java","-Dfile.encoding=UTF-8","-jar","/app/app.jar"]


### PR DESCRIPTION
This pull request updates the base Docker image used for running the application. The change switches from the Alpine-based `eclipse-temurin:17-jre-alpine` image to the standard `eclipse-temurin:17-jre` image, which may affect compatibility, image size, and runtime dependencies.

Container base image update:

* Changed the runtime Docker image from `eclipse-temurin:17-jre-alpine` to `eclipse-temurin:17-jre` in `Dockerfile`, removing Alpine Linux as the base.