### PR TITLE
Remove unnecessary Qualifier from PostDeleteEventListener

### DIFF
--- a/src/main/java/com/eventitta/post/event/PostDeleteEventListener.java
+++ b/src/main/java/com/eventitta/post/event/PostDeleteEventListener.java
@@ -2,7 +2,6 @@ package com.eventitta.post.event;
 
 import com.eventitta.file.service.FileStorageService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,7 +13,7 @@ public class PostDeleteEventListener {
     private final FileStorageService fileStorageService;
 
     public PostDeleteEventListener(
-        @Qualifier(value = "localFileStorageService") FileStorageService fileStorageService) {
+        FileStorageService fileStorageService) {
         this.fileStorageService = fileStorageService;
     }
 


### PR DESCRIPTION
## 요약
PostDeleteEventListener 의존성 주입 간소화

## 변경 유형
- [x] 코드 리팩토링 (의존성 주입 방식 단순화)
- [x] 코드 정리 (불필요한 어노테이션 및 import 제거)

## 변경 내용
**의존성 주입 단순화:**
- `PostDeleteEventListener` 생성자에서 `@Qualifier("localFileStorageService")` 어노테이션 제거
- `FileStorageService` 파라미터의 빈 주입을 더 유연하게 변경
- 사용하지 않는 `Qualifier` import 제거

## 변경 이유
**코드 단순화 및 유연성 향상:**
- 명시적 Qualifier 제거로 Spring의 기본 빈 주입 메커니즘 활용
- 코드 가독성 향상 및 불필요한 복잡성 제거
- 향후 다른 FileStorageService 구현체로 쉽게 교체 가능

**유지보수성 개선:**
- 하드코딩된 빈 이름 의존성 제거
- Spring 설정 변경 시 코드 수정 불필요

## 테스트 방법
1. **의존성 주입 확인:**
   - `PostDeleteEventListener` 빈이 정상적으로 생성되는지 확인
   - `FileStorageService` 빈이 올바르게 주입되는지 확인

2. **기능 동작 검증:**
   - 게시글 삭제 시 이벤트 리스너 정상 동작 확인
   - 파일 삭제 기능 정상 작동 확인

## 체크리스트
- [x] @Qualifier 어노테이션 제거 완료
- [x] 불필요한 import 정리 완료
- [x] 의존성 주입 정상 동작 확인
- [x] 게시글 삭제 및 파일 정리 기능 정상 동작 확인

## 관련 이슈
<!-- 관련 이슈 번호가 있다면 링크 -->

## 추가 정보
**변경 전후 비교:**
```java
// Before
public PostDeleteEventListener(
    @Qualifier("localFileStorageService") FileStorageService fileStorageService
) {
    this.fileStorageService = fileStorageService;
}

// After  
public PostDeleteEventListener(FileStorageService fileStorageService) {
    this.fileStorageService = fileStorageService;
}
```

**Spring 빈 주입 방식:**
- Qualifier 제거 후 Spring이 타입 기반으로 적절한 빈 자동 주입
- 현재 FileStorageService 구현체가 하나뿐이므로 문제없이 동작
- 향후 여러 구현체 존재 시 @Primary 또는 다른 방식으로 조정 가능

**주의사항:**
- 여러 FileStorageService 구현체가 동시에 존재할 경우 빈 주입 모호성 발생 가능
- 그 경우 @Primary 어노테이션 또는 @Qualifier 재사용 고려 필요