### PR TITLE
refactor: PostDeleteEventListener에서 불필요한 @Qualifier 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY gradlew .
 RUN chmod +x gradlew
 RUN ./gradlew clean bootJar --no-daemon --warning-mode=none
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 

--- a/src/main/java/com/eventitta/post/event/PostDeleteEventListener.java
+++ b/src/main/java/com/eventitta/post/event/PostDeleteEventListener.java
@@ -2,7 +2,6 @@ package com.eventitta.post.event;
 
 import com.eventitta.file.service.FileStorageService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,7 +13,7 @@ public class PostDeleteEventListener {
     private final FileStorageService fileStorageService;
 
     public PostDeleteEventListener(
-        @Qualifier(value = "localFileStorageService") FileStorageService fileStorageService) {
+        FileStorageService fileStorageService) {
         this.fileStorageService = fileStorageService;
     }
 


### PR DESCRIPTION
This pull request makes a minor change to the constructor of `PostDeleteEventListener` to simplify dependency injection for `FileStorageService`. The change removes the use of the `@Qualifier` annotation, which previously specified `"localFileStorageService"` as the implementation.

* Dependency injection simplification:
  - Removed the `@Qualifier` annotation from the `PostDeleteEventListener` constructor, allowing Spring to inject the default `FileStorageService` bean without specifying `"localFileStorageService"`. [[1]](diffhunk://#diff-fbab40ee7efbf9336b97e19c3dd31fa1176d1337c4ac8aba11fb37bfe484c98eL5) [[2]](diffhunk://#diff-fbab40ee7efbf9336b97e19c3dd31fa1176d1337c4ac8aba11fb37bfe484c98eL17-R16)