### PR TITLE
chore: .dockerignore에서 불필요한 '**/db/' 패턴 제거

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 db/
-**/db/
 build/
 .gradle/
 out/


### PR DESCRIPTION
This pull request makes a small update to the `.dockerignore` file to improve the Docker build context. The change removes a redundant ignore pattern for the `db/` directory.