### PR TITLE
refactor: 엔티티 @Table 이름을 복수형으로 변경

### DIFF
--- a/src/main/java/com/eventitta/meeting/domain/Meeting.java
+++ b/src/main/java/com/eventitta/meeting/domain/Meeting.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 
 @Entity
+@Table(name = "meetings")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/eventitta/meeting/domain/MeetingParticipant.java
+++ b/src/main/java/com/eventitta/meeting/domain/MeetingParticipant.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-    name = "meeting_participant",
+    name = "meeting_participants",
     uniqueConstraints = @UniqueConstraint(columnNames = {"meeting_id", "user_id"})
 )
 @Getter

--- a/src/main/java/com/eventitta/post/domain/PostLike.java
+++ b/src/main/java/com/eventitta/post/domain/PostLike.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "post_like",
+@Table(name = "post_likes",
     uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
 public class PostLike {
     @Id

--- a/src/main/java/com/eventitta/region/domain/Region.java
+++ b/src/main/java/com/eventitta/region/domain/Region.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "region")
+@Table(name = "regions")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
This pull request standardizes the naming conventions for database tables by updating several entity classes to use plural table names. This change improves consistency and aligns with common best practices for table naming in relational databases.

**Database table naming standardization:**

* Changed the table name in the `Meeting` entity from the default to `meetings`.
* Changed the table name in the `MeetingParticipant` entity from `meeting_participant` to `meeting_participants`.
* Changed the table name in the `PostLike` entity from `post_like` to `post_likes`.
* Changed the table name in the `Region` entity from `region` to `regions`.