### PR TITLE
refactor: BaseTimeEntity 기반 감사필드(Auditing) 수정 및 festivals 스키마 정리

### DIFF
--- a/src/main/java/com/eventitta/auth/domain/RefreshToken.java
+++ b/src/main/java/com/eventitta/auth/domain/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.eventitta.auth.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -17,7 +18,7 @@ import java.time.ZoneId;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "refresh_tokens")
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,16 +30,12 @@ public class RefreshToken {
     @Column(name = "token_hash", nullable = false, length = 255)
     private String tokenHash;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
     public RefreshToken(User user, String tokenHash, Instant expiresAt) {
         this.user = user;
         this.tokenHash = tokenHash;
-        this.createdAt = LocalDateTime.now();
         this.expiresAt = LocalDateTime.ofInstant(expiresAt, ZoneId.systemDefault());
     }
 

--- a/src/main/java/com/eventitta/common/config/BaseTimeEntity.java
+++ b/src/main/java/com/eventitta/common/config/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.eventitta.common.config;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/eventitta/common/config/BaseUserEntity.java
+++ b/src/main/java/com/eventitta/common/config/BaseUserEntity.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity extends BaseTimeEntity {
+public abstract class BaseUserEntity {
 
     @CreatedBy
     @Column(name = "created_by", length = 100, updatable = false)

--- a/src/main/java/com/eventitta/festivals/domain/Festival.java
+++ b/src/main/java/com/eventitta/festivals/domain/Festival.java
@@ -1,5 +1,6 @@
 package com.eventitta.festivals.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,7 @@ import java.time.LocalDate;
     })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Festival extends BaseEntity {
+public class Festival extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -75,26 +76,11 @@ public class Festival extends BaseEntity {
     @Column(name = "organizer", length = 500)
     private String organizer; // 주관기관/기관명
 
-    @Column(name = "host", length = 500)
-    private String host; // 주최기관 (전국축제만)
-
-    @Column(name = "supporter", length = 500)
-    private String supporter; // 후원기관 (전국축제만)
-
-    @Column(name = "phone_number", length = 50)
-    private String phoneNumber;
-
     @Column(name = "homepage_url", length = 1000)
     private String homepageUrl;
 
     @Column(name = "detail_url", length = 1000)
     private String detailUrl; // 상세페이지 URL
-
-    @Column(name = "road_address", length = 500)
-    private String roadAddress;
-
-    @Column(name = "jibun_address", length = 500)
-    private String jibunAddress;
 
     @Column(precision = 10, scale = 7)
     private BigDecimal latitude;
@@ -104,9 +90,6 @@ public class Festival extends BaseEntity {
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content; // 행사내용/기타내용
-
-    @Column(name = "related_info", columnDefinition = "TEXT")
-    private String relatedInfo; // 관련정보 (전국축제만)
 
     @Enumerated(EnumType.STRING)
     @Column(name = "data_source", nullable = false)
@@ -120,10 +103,9 @@ public class Festival extends BaseEntity {
     private Festival(String title, String venue, LocalDate startDate, LocalDate endDate,
                      String category, String district, String targetAudience, String feeInfo,
                      Boolean isFree, String performers, String programInfo, String mainImageUrl,
-                     String themeCode, String ticketType, String organizer, String host,
-                     String supporter, String phoneNumber, String homepageUrl, String detailUrl,
-                     String roadAddress, String jibunAddress, BigDecimal latitude, BigDecimal longitude,
-                     String content, String relatedInfo, DataSource dataSource, String externalId) {
+                     String themeCode, String ticketType, String organizer, String homepageUrl, String detailUrl,
+                     BigDecimal latitude, BigDecimal longitude,
+                     String content, DataSource dataSource, String externalId) {
         this.title = title;
         this.venue = venue;
         this.startDate = startDate;
@@ -139,17 +121,11 @@ public class Festival extends BaseEntity {
         this.themeCode = themeCode;
         this.ticketType = ticketType;
         this.organizer = organizer;
-        this.host = host;
-        this.supporter = supporter;
-        this.phoneNumber = phoneNumber;
         this.homepageUrl = homepageUrl;
         this.detailUrl = detailUrl;
-        this.roadAddress = roadAddress;
-        this.jibunAddress = jibunAddress;
         this.latitude = latitude;
         this.longitude = longitude;
         this.content = content;
-        this.relatedInfo = relatedInfo;
         this.dataSource = dataSource;
         this.externalId = externalId;
     }
@@ -228,6 +204,5 @@ public class Festival extends BaseEntity {
         this.latitude = updatedFestival.getLatitude();
         this.longitude = updatedFestival.getLongitude();
         this.content = updatedFestival.getContent();
-        // updatedAt은 @UpdateTimestamp로 자동 갱신됨
     }
 }

--- a/src/main/java/com/eventitta/gamification/domain/ActivityType.java
+++ b/src/main/java/com/eventitta/gamification/domain/ActivityType.java
@@ -1,5 +1,6 @@
 package com.eventitta.gamification.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "activity_types")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ActivityType {
+public class ActivityType extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,4 +38,3 @@ public class ActivityType {
         this(null, code, name, defaultPoint);
     }
 }
-

--- a/src/main/java/com/eventitta/gamification/domain/Badge.java
+++ b/src/main/java/com/eventitta/gamification/domain/Badge.java
@@ -1,5 +1,6 @@
 package com.eventitta.gamification.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "badges")
-public class Badge {
+public class Badge extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
+++ b/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
@@ -1,5 +1,6 @@
 package com.eventitta.gamification.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "badge_rules")
-public class BadgeRule {
+public class BadgeRule extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/eventitta/gamification/domain/UserActivity.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserActivity.java
@@ -1,24 +1,20 @@
 package com.eventitta.gamification.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Table(
     name = "user_activities",
     uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "activity_type_id", "target_id"})
 )
 @AllArgsConstructor
 @Builder
-public class UserActivity {
+public class UserActivity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,10 +33,6 @@ public class UserActivity {
 
     @Column(nullable = false)
     private Long targetId;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
 
     public UserActivity(User user, ActivityType activityType, Long targetId) {
         this.user = user;

--- a/src/main/java/com/eventitta/gamification/domain/UserBadge.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserBadge.java
@@ -1,22 +1,18 @@
 package com.eventitta.gamification.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "user_badges",
     uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "badge_id"}))
-public class UserBadge {
+public class UserBadge extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,10 +25,6 @@ public class UserBadge {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "badge_id", nullable = false)
     private Badge badge;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
 
     public UserBadge(User user, Badge badge) {
         this.user = user;

--- a/src/main/java/com/eventitta/gamification/service/UserActivityService.java
+++ b/src/main/java/com/eventitta/gamification/service/UserActivityService.java
@@ -89,6 +89,7 @@ public class UserActivityService {
         ActivityType activityType = activityTypeRepository.findByCode(activityCode)
             .orElseThrow(INVALID_ACTIVITY_TYPE::defaultException);
 
+        // 멱등성 처리 관련 -> 조건 문을 주어서 조회되지 않는 경우 return 시키면 됨
         userActivityRepository.findByUserIdAndActivityType_IdAndTargetId(userId, activityType.getId(), targetId)
             .ifPresent(activity -> {
                 UserPoints userPoints = userPointsRepository.findByUserId(userId)

--- a/src/main/java/com/eventitta/meeting/domain/Meeting.java
+++ b/src/main/java/com/eventitta/meeting/domain/Meeting.java
@@ -1,5 +1,6 @@
 package com.eventitta.meeting.domain;
 
+import com.eventitta.common.config.BaseEntity;
 import com.eventitta.meeting.dto.request.MeetingUpdateRequest;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
@@ -16,7 +17,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Meeting {
+public class Meeting extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/eventitta/meeting/domain/MeetingParticipant.java
+++ b/src/main/java/com/eventitta/meeting/domain/MeetingParticipant.java
@@ -1,5 +1,6 @@
 package com.eventitta.meeting.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MeetingParticipant {
+public class MeetingParticipant extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/eventitta/post/domain/PostLike.java
+++ b/src/main/java/com/eventitta/post/domain/PostLike.java
@@ -1,14 +1,13 @@
 package com.eventitta.post.domain;
 
+import com.eventitta.common.config.BaseTimeEntity;
 import com.eventitta.user.domain.User;
 import jakarta.persistence.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "post_likes",
     uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
-public class PostLike {
+public class PostLike extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -21,15 +20,12 @@ public class PostLike {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private LocalDateTime likedAt;
-
     protected PostLike() {
     }
 
     public PostLike(Post post, User user) {
         this.post = post;
         this.user = user;
-        this.likedAt = LocalDateTime.now();
     }
 
     public Long getId() {
@@ -42,9 +38,5 @@ public class PostLike {
 
     public User getUser() {
         return user;
-    }
-
-    public LocalDateTime getLikedAt() {
-        return likedAt;
     }
 }

--- a/src/main/resources/db/migration/V4__Update_audit_fields.sql
+++ b/src/main/resources/db/migration/V4__Update_audit_fields.sql
@@ -1,0 +1,62 @@
+-- V4: Update audit fields based on new BaseEntity hierarchy
+
+-- 1. Festival 테이블에서 created_by, updated_by 컬럼 제거 (BaseTimeEntity로 변경됨)
+ALTER TABLE festivals
+  DROP COLUMN created_by,
+  DROP COLUMN updated_by;
+
+-- 1-2. Festival 테이블에서 제거된 기존 필드들 삭제
+ALTER TABLE festivals
+  DROP COLUMN host,
+  DROP COLUMN supporter,
+  DROP COLUMN phone_number,
+  DROP COLUMN road_address,
+  DROP COLUMN jibun_address,
+  DROP COLUMN related_info;
+
+-- 2. meeting_participants 테이블에 BaseTimeEntity 필드 추가
+ALTER TABLE meeting_participants
+  ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- 3. post_likes 테이블에 BaseTimeEntity 필드 추가하고 기존 liked_at 컬럼 제거
+ALTER TABLE post_likes
+  ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- 기존 liked_at 데이터를 created_at으로 이전
+UPDATE post_likes
+SET created_at = liked_at
+WHERE liked_at IS NOT NULL;
+
+-- liked_at 컬럼 제거
+ALTER TABLE post_likes
+  DROP COLUMN liked_at;
+
+-- 4. refresh_tokens 테이블의 BaseTimeEntity 적용
+-- 기존 created_at 컬럼을 임시로 백업하고 새로운 audit 필드 추가
+ALTER TABLE refresh_tokens
+  ADD COLUMN new_created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- 기존 created_at 데이터를 new_created_at으로 복사
+UPDATE refresh_tokens
+SET new_created_at = created_at
+WHERE created_at IS NOT NULL;
+
+-- 기존 created_at 컬럼 제거하고 new_created_at을 created_at으로 변경
+ALTER TABLE refresh_tokens
+  DROP COLUMN created_at;
+
+ALTER TABLE refresh_tokens
+  CHANGE COLUMN new_created_at created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
+
+-- 5. 인덱스 정리 및 추가
+ALTER TABLE meeting_participants
+  ADD INDEX idx_meeting_participants_created_at (created_at);
+
+ALTER TABLE post_likes
+  ADD INDEX idx_post_likes_created_at (created_at);
+
+ALTER TABLE refresh_tokens
+  ADD INDEX idx_refresh_tokens_created_at (created_at);

--- a/src/main/resources/db/migration/V5__Remove_unused_festival_fields.sql
+++ b/src/main/resources/db/migration/V5__Remove_unused_festival_fields.sql
@@ -1,0 +1,36 @@
+-- V5: Remove unused festival fields and update gamification domain audit fields
+
+-- 1. Gamification 도메인 테이블들에 BaseTimeEntity 필드 추가
+
+-- activity_types 테이블에 audit 필드 추가
+ALTER TABLE activity_types
+  ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- badges 테이블에 audit 필드 추가
+ALTER TABLE badges
+  ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- badge_rules 테이블에 audit 필드 추가
+ALTER TABLE badge_rules
+  ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- user_activities 테이블에 updated_at 필드만 추가 (created_at과 인덱스는 이미 존재)
+ALTER TABLE user_activities
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- user_badges 테이블에 updated_at 필드만 추가 (created_at과 인덱스는 이미 존재)
+ALTER TABLE user_badges
+  ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+-- 2. 새로 추가된 테이블들에만 인덱스 추가 (기존 테이블 제외)
+ALTER TABLE activity_types
+  ADD INDEX idx_activity_types_created_at (created_at);
+
+ALTER TABLE badges
+  ADD INDEX idx_badges_created_at (created_at);
+
+ALTER TABLE badge_rules
+  ADD INDEX idx_badge_rules_created_at (created_at);


### PR DESCRIPTION
## 요약
Auditing 리팩토링 (BaseTimeEntity 도입) 및 Festivals 스키마 정리

- `BaseTimeEntity` / `BaseUserEntity` 추가로 감사필드 구조 일원화
- 불필요한 Festival 관련 컬럼 제거
- Flyway 마이그레이션 스크립트 반영

## 변경 유형
- [x] 코드 리팩토링 (Auditing 구조 개선)
- [x] 아키텍처 개선 (공통 BaseEntity 분리)
- [x] DB 스키마 정리 (불필요 컬럼 제거 및 마이그레이션 반영)

## 변경 내용
**Auditing 구조 리팩토링:**
- `BaseTimeEntity` 추가 → `createdAt`, `updatedAt` 필드 중앙화 (JPA Auditing 적용)
- `BaseUserEntity` 추가 → `createdBy`, `updatedBy` 사용자 감사 필드 관리
- 기존 `BaseEntity`는 `BaseTimeEntity` 상속 후 user 필드만 유지하도록 변경

**도메인 엔티티 업데이트:**
- `Festival`, `RefreshToken`, `ActivityType`, `Badge`, `UserActivity`, `UserBadge`, `MeetingParticipant`, `PostLike` 등 주요 엔티티가 `BaseTimeEntity` 상속
- 생성/수정 시간 필드 일관성 확보

**필드 정리 및 중복 제거:**
- `Festival`에서 더 이상 사용되지 않는 컬럼 제거  
  (예: `host`, `supporter`, `phoneNumber`, `roadAddress`, `jibunAddress`, `relatedInfo`)
- 각 엔티티에서 중복된 `createdAt`, `updatedAt` 제거 → `BaseTimeEntity`로 대체

**기타 개선:**
- 코드 주석 보강 및 불필요한 메서드/생성자 정리
- Gamification, Meeting 도메인에도 동일한 감사필드 패턴 적용

## 변경 이유
- **유지보수성**: 감사필드 공통화로 중복 코드 제거 및 엔티티 간 일관성 확보  
- **스키마 단순화**: 사용되지 않는 Festival 관련 필드 제거로 쿼리 단순화 및 성능 개선  
- **확장성**: 향후 도메인 추가 시 감사필드 일관되게 적용 가능  

## 테스트 방법
1. Festival, Meeting, Gamification 등 엔티티 생성/수정 시 `createdAt`, `updatedAt` 값이 정상 반영되는지 확인  
2. 삭제된 컬럼(`host`, `supporter`, …)이 Flyway 마이그레이션 후 DB에서 제거되었는지 확인  
3. API 호출(`/api/v1/festivals/nearby`, `/api/v1/meetings`) 시 감사필드 정상 동작 여부 검증  

## 체크리스트
- [x] BaseTimeEntity / BaseUserEntity 적용 확인  
- [x] Festival 불필요 컬럼 제거 완료  
- [x] Flyway 마이그레이션 반영 및 정상 실행  
- [x] 주요 엔티티 CRUD 정상 동작 검증  

## 관련 이슈
<!-- 예: #123 -->

## 추가 정보
**엔티티 구조 변화:**
```java
@MappedSuperclass
@EntityListeners(AuditingEntityListener.class)
public abstract class BaseTimeEntity {
    @CreatedDate
    private LocalDateTime createdAt;
    @LastModifiedDate
    private LocalDateTime updatedAt;
}

Festival 변경 전 → 후 예시:

// Before
private String host;
private String supporter;
private String phoneNumber;
private String roadAddress;
private String jibunAddress;
private String relatedInfo;
private LocalDateTime createdAt;
private LocalDateTime updatedAt;

// After
// (위 필드 삭제, createdAt/updatedAt은 BaseTimeEntity 상속으로 자동 포함)