### PR TITLE
Expand Actuator health endpoint access and improve JWT filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,6 @@ jobs:
             -t ahnco/eventitta:$VERSION \
             -t ahnco/eventitta:latest \
             .
-
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
@@ -99,8 +99,7 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(auth ->
                 auth
-                    // Actuator health는 public
-                    .requestMatchers("/actuator/health").permitAll()
+                    .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                     // 나머지 Actuator는 ADMIN만
                     .requestMatchers("/actuator/**").hasRole("ADMIN")
                     // 기존 public 엔드포인트

--- a/src/main/java/com/eventitta/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eventitta/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -18,6 +19,16 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+    private static final String[] WHITELIST = {
+        "/actuator/**",
+        "/v3/api-docs/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/api/v1/auth/**",
+        "/error",
+        "/favicon.ico"
+    };
 
     public JwtAuthenticationFilter(JwtTokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
@@ -50,7 +61,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) return true;
+
         String path = request.getRequestURI();
-        return path.startsWith("/api/v1/auth/");
+        for (String pattern : WHITELIST) {
+            if (PATH_MATCHER.match(pattern, path)) return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## 요약

보안 설정 및 요청 필터링 로직을 개선하여 공개 엔드포인트 관리의 유연성과 유지보수성을 높였습니다. Actuator 헬스 체크 접근 권한을 확대하고, JWT 인증 제외 대상을 중앙 집중화하여 관리하도록 리팩토링했습니다.

## 주요 변경사항

* **Actuator 접근 권한 확대**: `SecurityConfig.java`에서 `/actuator/health`뿐만 아니라 하위 경로인 `/actuator/health/**` 전체에 대해 인증 없이 접근할 수 있도록 허용 범위를 넓혔습니다.
* **JWT 필터 화이트리스트 도입**: `JwtAuthenticationFilter.java`에 `WHITELIST` 배열과 `AntPathMatcher`를 도입하여 인증을 거치지 않을 엔드포인트 패턴을 한곳에서 관리하도록 개선했습니다.
* **필터 제외 로직(shouldNotFilter) 리팩토링**:
* CORS 프리플라이트 요청인 모든 HTTP `OPTIONS` 요청을 즉시 허용하도록 변경했습니다.
* 기존의 하드코딩된 특정 경로 체크 방식을 `WHITELIST`와 패턴 매칭 방식으로 교체하여 확장성을 확보했습니다.


* **기타**: 배포 워크플로우 파일(`deploy.yml`)의 가독성을 위한 단순 포맷 수정을 진행했습니다.

**동적으로 바뀔 변경사항**

* `WHITELIST` 배열에 정의된 경로 패턴에 따라 인증 필터 적용 여부가 실시간으로 결정되어 처리됩니다.
* 클라이언트로부터 들어오는 HTTP 메서드가 `OPTIONS`인 경우, 별도의 인증 로직을 타지 않고 즉시 통과됩니다.

## 주요 효과

* 화이트리스트 중앙 관리를 통해 향후 공개 엔드포인트가 추가되거나 변경될 때의 유지보수 효율이 향상되었습니다.
* 모든 `OPTIONS` 요청을 허용함으로써 브라우저의 CORS 프리플라이트 과정에서 발생할 수 있는 인증 오류를 원천 차단했습니다.
* 헬스 체크 엔드포인트에 대한 접근성을 높여 외부 모니터링 도구와의 연동 안정성을 확보했습니다.