### PR TITLE
Remove duplicate logging file path configuration

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!-- 속성 정의 -->
-  <property name="LOG_PATH" value="${LOG_PATH:-/app/logs}"/>
-  <property name="LOG_FILE" value="${LOG_FILE:-eventitta}"/>
+  <property name="LOG_DIR" value="${LOG_PATH:-/app/logs}"/>
+  <property name="LOG_FILE_NAME" value="eventitta"/>
   <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
   <!-- 콘솔 Appender (local, test 프로파일용) -->
@@ -19,14 +19,14 @@
   <springProfile name="prod">
     <!-- 일반 로그 파일 Appender (7일 보관) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${LOG_PATH}/${LOG_FILE}.log</file>
+      <file>${LOG_DIR}/${LOG_FILE_NAME}.log</file>
       <encoder>
         <pattern>${LOG_PATTERN}</pattern>
         <charset>UTF-8</charset>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
         <!-- 파일명 패턴: eventitta-2025-10-21.0.log.gz -->
-        <fileNamePattern>${LOG_PATH}/${LOG_FILE}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <fileNamePattern>${LOG_DIR}/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
         <!-- 최대 파일 크기 -->
         <maxFileSize>50MB</maxFileSize>
         <!-- 보관 기간: 7일 -->
@@ -44,13 +44,13 @@
 
     <!-- 에러 전용 로그 파일 Appender (30일 보관) -->
     <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${LOG_PATH}/error.log</file>
+      <file>${LOG_DIR}/error.log</file>
       <encoder>
         <pattern>${LOG_PATTERN}</pattern>
         <charset>UTF-8</charset>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/error-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <fileNamePattern>${LOG_DIR}/error-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
         <maxFileSize>30MB</maxFileSize>
         <!-- 에러 로그는 30일 보관 (장애 추적용) -->
         <maxHistory>30</maxHistory>
@@ -131,13 +131,13 @@
   <springProfile name="local">
     <!-- 로컬 환경용 파일 Appender -->
     <appender name="LOCAL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>./logs/eventitta.log</file>
+      <file>./logs/${LOG_FILE_NAME}.log</file>
       <encoder>
         <pattern>${LOG_PATTERN}</pattern>
         <charset>UTF-8</charset>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>./logs/eventitta-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <fileNamePattern>./logs/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
         <maxFileSize>10MB</maxFileSize>
         <maxHistory>3</maxHistory>
         <totalSizeCap>30MB</totalSizeCap>


### PR DESCRIPTION


## 요약

logback-spring.xml 내 로그 관련 프로퍼티 명명 규칙을 표준화하여 가독성과 유지보수성을 개선함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* 기존 LOG_PATH 프로퍼티를 LOG_DIR로 변경하여 디렉토리의 의미를 명확히 함
* 기존 LOG_FILE 프로퍼티를 LOG_FILE_NAME으로 변경하여 파일명임을 명시함
* 운영(Production) 프로필 내 로그 파일 위치 및 파일 이름 패턴 참조를 신규 프로퍼티명으로 전면 교체
* 로컬(Local) 프로필에서도 LOG_FILE_NAME 프로퍼티를 사용하도록 수정하여 환경 간 일관성 유지

## 주요 효과

* 로그 설정 내 변수명 혼선 방지 및 설정값의 의미를 직관적으로 파악 가능
* 로컬과 운영 환경의 설정 구조를 통일하여 향후 설정 확장 및 관리 편의성 증대

