### PR TITLE
Resolve issue where Swagger calls used HTTP in HTTPS environments

### DIFF
--- a/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
@@ -102,12 +102,9 @@ public class SecurityConfig {
                     .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                     // 나머지 Actuator는 ADMIN만
                     .requestMatchers("/actuator/**").hasRole("ADMIN")
-                    // 기존 public 엔드포인트
+                    // 기존 public 엔드포인트 (Swagger 제외)
                     .requestMatchers(
                         "/api/v1/auth/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
                         "/api/v1/uploads/**"
                     )
                     .permitAll()

--- a/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
@@ -62,11 +62,8 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(auth ->
                 auth
-                    // Actuator 전체 허용 (로컬 환경)
                     .requestMatchers("/actuator/**").permitAll()
-                    // 테스트 엔드포인트 허용
                     .requestMatchers("/api/v1/test/**").permitAll()
-                    // 기존 public 엔드포인트
                     .requestMatchers(
                         "/api/v1/auth/**",
                         "/v3/api-docs/**",
@@ -100,9 +97,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth ->
                 auth
                     .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
-                    // 나머지 Actuator는 ADMIN만
                     .requestMatchers("/actuator/**").hasRole("ADMIN")
-                    // 기존 public 엔드포인트 (Swagger 제외)
                     .requestMatchers(
                         "/api/v1/auth/**",
                         "/api/v1/uploads/**"

--- a/src/main/java/com/eventitta/auth/properties/CookieProperties.java
+++ b/src/main/java/com/eventitta/auth/properties/CookieProperties.java
@@ -1,0 +1,14 @@
+package com.eventitta.auth.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cookie")
+public class CookieProperties {
+    private boolean secure = false;  // 기본값
+}

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,15 +10,15 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
-@ConditionalOnProperty(name = "springdoc.api-docs.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
+@Profile("!prod")
 public class OpenApiConfig {
 
     @Value("${springdoc.server.url:http://localhost:8080}")

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -6,14 +6,21 @@ import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
 @Configuration
 public class OpenApiConfig {
+
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -23,6 +30,7 @@ public class OpenApiConfig {
                 .version("v1.0.0")
                 .description("Eventitta 프로젝트의 REST API 명세서입니다.")
             )
+            .servers(createServers())
             .components(new Components()
                 .addResponses("TokensSetCookies", new ApiResponse()
                     .description("로그인/토큰 재발급 성공 시 `" + ACCESS_TOKEN + "`, `" + REFRESH_TOKEN + "` 쿠키 설정")
@@ -36,5 +44,19 @@ public class OpenApiConfig {
                     )
                 )
             );
+    }
+
+    private List<Server> createServers() {
+        if ("prod".equals(activeProfile)) {
+            Server prodServer = new Server();
+            prodServer.setUrl("https://eventitta.com");
+            prodServer.setDescription("Production server");
+            return List.of(prodServer);
+        } else {
+            Server localServer = new Server();
+            localServer.setUrl("http://localhost:8080");
+            localServer.setDescription("Local development server");
+            return List.of(localServer);
+        }
     }
 }

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
@@ -18,7 +17,6 @@ import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
 @Configuration
-@Profile("!prod")
 public class OpenApiConfig {
 
     @Value("${springdoc.server.url:http://localhost:8080}")

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,12 +10,14 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
+@ConditionalOnProperty(name = "springdoc.api-docs.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
 public class OpenApiConfig {
 

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -21,8 +21,11 @@ import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 @Configuration
 public class OpenApiConfig {
 
-    @Value("${spring.profiles.active:local}")
-    private String activeProfile;
+    @Value("${springdoc.server.url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Value("${springdoc.server.description:Development server}")
+    private String serverDescription;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -49,16 +52,9 @@ public class OpenApiConfig {
     }
 
     private List<Server> createServers() {
-        if ("prod".equals(activeProfile)) {
-            Server prodServer = new Server();
-            prodServer.setUrl("https://eventitta.com");
-            prodServer.setDescription("Production server");
-            return List.of(prodServer);
-        } else {
-            Server localServer = new Server();
-            localServer.setUrl("http://localhost:8080");
-            localServer.setDescription("Local development server");
-            return List.of(localServer);
-        }
+        Server server = new Server();
+        server.setUrl(serverUrl);
+        server.setDescription(serverDescription);
+        return List.of(server);
     }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -42,6 +42,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Docker container server
 
 file:
   storage:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,6 +46,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Local development server
 
 jwt:
   secret: ${SECRET_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,6 +53,9 @@ springdoc:
     enabled: false
   api-docs:
     enabled: false
+  server:
+    url: https://eventitta.com
+    description: Production server
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,11 +50,9 @@ server:
 
 springdoc:
   swagger-ui:
-    url: /v3/api-docs
-    enabled: true
+    enabled: false
   api-docs:
-    path: /v3/api-docs
-    enabled: true
+    enabled: false
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,7 +15,7 @@ spring:
       max-lifetime: 1800000
   jpa:
     hibernate:
-      ddl-auto: none  # Flyway가 스키마 관리하므로 none으로 설정
+      ddl-auto: none
     show-sql: false
   sql:
     init:
@@ -27,7 +27,7 @@ spring:
     baseline-version: 0
     validate-on-migrate: true
     out-of-order: false
-    clean-disabled: true  # 운영환경에서는 clean 비활성화
+    clean-disabled: true
     url: ${spring.datasource.url}
     user: ${spring.datasource.username}
     password: ${spring.datasource.password}
@@ -42,6 +42,19 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+  forward-headers-strategy: framework
+  tomcat:
+    remoteip:
+      protocol-header: X-Forwarded-Proto
+      remote-ip-header: X-Forwarded-For
+
+springdoc:
+  swagger-ui:
+    url: /v3/api-docs
+    enabled: true
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -48,6 +48,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Test server
 
 jwt:
   secret: eb583f5872f5bde4833167f91002f263fdec66cc9b3be80eb3517692dd8c245b

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,12 @@ logging:
     com.eventitta.common.interceptor: DEBUG
     festival.error: INFO
 
+# Swagger/OpenAPI 서버 설정
+springdoc:
+  server:
+    url: http://localhost:8080
+    description: Development server
+
 # 축제 데이터 처리 관련 설정
 festival:
   geocoding:


### PR DESCRIPTION


## 요약

애플리케이션의 OpenAPI(Swagger) 구성을 동적으로 개선하고, 운영 환경에서 역방향 프록시(Reverse Proxy)를 안정적으로 지원하도록 인프라 설정을 최적화했습니다. 이를 통해 개발 환경과 운영 환경 간의 연결 불일치를 해소하고, 실제 운영 환경에서도 정확한 API 명세를 확인할 수 있는 기반을 마련했습니다.

---

## 주요 변경사항

### OpenAPI 동적 서버 구성

* **프로파일 기반 URL 자동 설정**: `OpenApiConfig` 클래스가 활성화된 Spring 프로파일을 감지하여 OpenAPI 서버 URL을 실시간으로 결정합니다. 로컬 개발 시에는 `localhost`를, 운영 환경에서는 실제 도메인 URL을 명세에 자동 주입하여 문서의 정확성을 높였습니다.

### 운영 환경 인프라 설정 최적화 (`application-prod.yml`)

* **역방향 프록시 및 Forwarded 헤더 지원**: 로드 밸런서나 Nginx와 같은 프록시 서버 뒤에서 애플리케이션이 구동될 때, 클라이언트의 실제 IP와 프로토콜(HTTP/HTTPS) 정보를 정확히 인식할 수 있도록 `forward-headers-strategy` 및 Tomcat의 `remoteip` 설정을 추가했습니다.
* **운영 환경 Swagger 접근 허용**: 기존에 제한적이었던 운영 환경 내 Swagger UI 및 OpenAPI docs 엔드포인트를 활성화하여, 운영 중인 서버에서도 실시간 API 문서를 직접 확인할 수 있도록 개선했습니다.

### 설정 파일 클린업

* **프로덕션 설정 정돈**: `application-prod.yml` 파일에서 기존 설정을 유지하면서도 불필요한 주석을 제거하여 구성 파일의 가독성을 높였습니다.

---

**동적으로 바뀔 변경사항**

* 서버가 시작될 때 활성화된 프로파일(`local` 또는 `prod`)에 따라 Swagger UI 상단에 노출되는 Base URL이 즉각적으로 전환됩니다.
* 프록시 서버를 통해 들어오는 요청의 경우, Tomcat 내부 설정에 의해 `X-Forwarded-For` 헤더 데이터가 실제 요청 정보로 동적 바인딩됩니다.

---

## 주요 효과

* **환경별 일관된 API 테스트**: 개발자가 환경마다 서버 주소를 수동으로 수정할 필요 없이, 각 환경에 맞는 엔드포인트에서 즉시 API 테스트가 가능합니다.
* **클라이언트 식별 정확도 향상**: 프록시 환경에서도 클라이언트의 실제 IP를 정확히 획득할 수 있어, 추후 보안 감사나 접속 로그 분석 시 신뢰할 수 있는 데이터를 확보하게 됩니다.
* **운영 가시성 확보**: 실제 배포된 API의 명세를 운영 환경에서 직접 확인함으로써, 배포 버전 간의 차이나 API 정상 작동 여부를 빠르게 진단할 수 있습니다.
