### PR TITLE
Address Swagger mixed content issues and disable documentation in production

### DIFF
--- a/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
@@ -102,12 +102,9 @@ public class SecurityConfig {
                     .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                     // 나머지 Actuator는 ADMIN만
                     .requestMatchers("/actuator/**").hasRole("ADMIN")
-                    // 기존 public 엔드포인트
+                    // 기존 public 엔드포인트 (Swagger 제외)
                     .requestMatchers(
                         "/api/v1/auth/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
                         "/api/v1/uploads/**"
                     )
                     .permitAll()

--- a/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/eventitta/auth/jwt/config/SecurityConfig.java
@@ -62,11 +62,8 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .authorizeHttpRequests(auth ->
                 auth
-                    // Actuator 전체 허용 (로컬 환경)
                     .requestMatchers("/actuator/**").permitAll()
-                    // 테스트 엔드포인트 허용
                     .requestMatchers("/api/v1/test/**").permitAll()
-                    // 기존 public 엔드포인트
                     .requestMatchers(
                         "/api/v1/auth/**",
                         "/v3/api-docs/**",
@@ -100,9 +97,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth ->
                 auth
                     .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
-                    // 나머지 Actuator는 ADMIN만
                     .requestMatchers("/actuator/**").hasRole("ADMIN")
-                    // 기존 public 엔드포인트 (Swagger 제외)
                     .requestMatchers(
                         "/api/v1/auth/**",
                         "/api/v1/uploads/**"

--- a/src/main/java/com/eventitta/auth/properties/CookieProperties.java
+++ b/src/main/java/com/eventitta/auth/properties/CookieProperties.java
@@ -1,0 +1,14 @@
+package com.eventitta.auth.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cookie")
+public class CookieProperties {
+    private boolean secure = false;  // 기본값
+}

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,15 +10,15 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
-@ConditionalOnProperty(name = "springdoc.api-docs.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
+@Profile("!prod")
 public class OpenApiConfig {
 
     @Value("${springdoc.server.url:http://localhost:8080}")

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -6,14 +6,21 @@ import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
 @Configuration
 public class OpenApiConfig {
+
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -23,6 +30,7 @@ public class OpenApiConfig {
                 .version("v1.0.0")
                 .description("Eventitta 프로젝트의 REST API 명세서입니다.")
             )
+            .servers(createServers())
             .components(new Components()
                 .addResponses("TokensSetCookies", new ApiResponse()
                     .description("로그인/토큰 재발급 성공 시 `" + ACCESS_TOKEN + "`, `" + REFRESH_TOKEN + "` 쿠키 설정")
@@ -36,5 +44,19 @@ public class OpenApiConfig {
                     )
                 )
             );
+    }
+
+    private List<Server> createServers() {
+        if ("prod".equals(activeProfile)) {
+            Server prodServer = new Server();
+            prodServer.setUrl("https://eventitta.com");
+            prodServer.setDescription("Production server");
+            return List.of(prodServer);
+        } else {
+            Server localServer = new Server();
+            localServer.setUrl("http://localhost:8080");
+            localServer.setDescription("Local development server");
+            return List.of(localServer);
+        }
     }
 }

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
@@ -18,7 +17,6 @@ import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
 @Configuration
-@Profile("!prod")
 public class OpenApiConfig {
 
     @Value("${springdoc.server.url:http://localhost:8080}")

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -10,12 +10,14 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import java.util.List;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 
+@ConditionalOnProperty(name = "springdoc.api-docs.enabled", havingValue = "true", matchIfMissing = true)
 @Configuration
 public class OpenApiConfig {
 

--- a/src/main/java/com/eventitta/common/config/OpenApiConfig.java
+++ b/src/main/java/com/eventitta/common/config/OpenApiConfig.java
@@ -21,8 +21,11 @@ import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 @Configuration
 public class OpenApiConfig {
 
-    @Value("${spring.profiles.active:local}")
-    private String activeProfile;
+    @Value("${springdoc.server.url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Value("${springdoc.server.description:Development server}")
+    private String serverDescription;
 
     @Bean
     public OpenAPI customOpenAPI() {
@@ -49,16 +52,9 @@ public class OpenApiConfig {
     }
 
     private List<Server> createServers() {
-        if ("prod".equals(activeProfile)) {
-            Server prodServer = new Server();
-            prodServer.setUrl("https://eventitta.com");
-            prodServer.setDescription("Production server");
-            return List.of(prodServer);
-        } else {
-            Server localServer = new Server();
-            localServer.setUrl("http://localhost:8080");
-            localServer.setDescription("Local development server");
-            return List.of(localServer);
-        }
+        Server server = new Server();
+        server.setUrl(serverUrl);
+        server.setDescription(serverDescription);
+        return List.of(server);
     }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -42,6 +42,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Docker container server
 
 file:
   storage:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,6 +46,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Local development server
 
 jwt:
   secret: ${SECRET_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,6 +53,9 @@ springdoc:
     enabled: false
   api-docs:
     enabled: false
+  server:
+    url: https://eventitta.com
+    description: Production server
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,11 +50,9 @@ server:
 
 springdoc:
   swagger-ui:
-    url: /v3/api-docs
-    enabled: true
+    enabled: false
   api-docs:
-    path: /v3/api-docs
-    enabled: true
+    enabled: false
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,7 +15,7 @@ spring:
       max-lifetime: 1800000
   jpa:
     hibernate:
-      ddl-auto: none  # Flyway가 스키마 관리하므로 none으로 설정
+      ddl-auto: none
     show-sql: false
   sql:
     init:
@@ -27,7 +27,7 @@ spring:
     baseline-version: 0
     validate-on-migrate: true
     out-of-order: false
-    clean-disabled: true  # 운영환경에서는 clean 비활성화
+    clean-disabled: true
     url: ${spring.datasource.url}
     user: ${spring.datasource.username}
     password: ${spring.datasource.password}
@@ -42,6 +42,19 @@ spring:
 
 server:
   port: ${SERVER_PORT:8080}
+  forward-headers-strategy: framework
+  tomcat:
+    remoteip:
+      protocol-header: X-Forwarded-Proto
+      remote-ip-header: X-Forwarded-For
+
+springdoc:
+  swagger-ui:
+    url: /v3/api-docs
+    enabled: true
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -48,6 +48,9 @@ springdoc:
     operations-sorter: alpha
     with-credentials: true
     persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Test server
 
 jwt:
   secret: eb583f5872f5bde4833167f91002f263fdec66cc9b3be80eb3517692dd8c245b

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,12 @@ logging:
     com.eventitta.common.interceptor: DEBUG
     festival.error: INFO
 
+# Swagger/OpenAPI 서버 설정
+springdoc:
+  server:
+    url: http://localhost:8080
+    description: Development server
+
 # 축제 데이터 처리 관련 설정
 festival:
   geocoding:


### PR DESCRIPTION

## 요약

애플리케이션의 환경별 설정 관리 체계를 고도화하고, 운영 환경의 보안을 강화하기 위한 접근 제어 정책을 수립했습니다. 특히 쿠키 설정의 중앙화와 환경에 최적화된 OpenAPI 문서 자동화, 그리고 액추에이터(Actuator) 엔드포인트에 대한 정밀한 보안 규칙을 적용했습니다.

---

## 주요 변경사항

### 설정 및 프로퍼티 관리 개선

* **쿠키 설정 중앙화**: 쿠키 관련 보안 플래그와 설정을 통합 관리하는 `CookieProperties` 클래스를 신설했습니다. 이를 통해 세션 및 쿠키 보안 정책을 일관되게 유지할 수 있습니다.
* **환경별 API 서버 명세 자동화**: 모든 `application-*.yml` 파일에 `springdoc.server.url` 프로퍼티를 추가했습니다. 이를 통해 로컬, 테스트, 운영 등 각 환경에 맞는 API 서버 주소와 설명이 Swagger 문서에 자동으로 반영됩니다.

### OpenAPI/Swagger 문서화 고도화

* **동적 서버 구성**: `OpenApiConfig.java`를 수정하여 설정 파일에 정의된 서버 정보를 OpenAPI 스펙에 동적으로 주입합니다. 이제 어떤 환경에서 문서를 열더라도 해당 환경에 맞는 API 호출 경로가 표시됩니다.

### 보안 구성 최적화

* **액추에이터 접근 제어 강화**: `SecurityConfig.java`의 필터 체인을 세분화했습니다.
* 로컬/개발 환경: 디버깅 편의를 위해 액추에이터 및 테스트 엔드포인트를 전체 공개합니다.
* 운영/비로컬 환경: `/actuator/health`만 공개하며, 그 외 민감한 엔드포인트는 `ADMIN` 권한을 요구하도록 격리했습니다.


* **공개 엔드포인트 정돈**: 운영 환경에서 불필요하게 노출되던 Swagger 관련 경로들을 접근 제한 목록으로 이동시켜 보안 노출면을 최소화했습니다.

### 운영 환경 보안 강화(Hardening)

* **API 문서 노출 차단**: 프로덕션 환경(`application-prod.yml`)에서 Swagger UI와 API docs 기능을 완전히 비활성화하여 외부로의 인터페이스 노출을 차단했습니다.
* **프록시 서버 지원**: 로드 밸런서나 리버스 프록시 뒤에서 실행되는 환경을 고려하여, 원격 IP 및 전달 서버 정보를 정확히 인식할 수 있도록 포워딩 설정을 추가했습니다.

---

## 동적으로 바뀔 변경사항

* 현재 활성화된 Spring 프로파일에 따라 Swagger UI 상단에 표시되는 서버 주소와 설명이 실시간으로 교체됩니다.
* 실행 환경이 `prod`인 경우, Swagger UI 접속 시도 시 404 또는 403 오류를 반환하며 문서가 렌더링되지 않습니다.
* 운영 환경에서는 일반 사용자나 외부인이 액추에이터의 상태 확인(Health) 외의 상세 지표를 조회하려 할 때 보안 필터에 의해 동적으로 차단됩니다.

---

## 주요 효과

* **보안성 극대화**: 민감한 시스템 지표와 API 명세를 운영 환경에서 격리함으로써 정보 유출 위험을 원천 차단했습니다.
* **운영 환경의 정확한 정보 제공**: 환경별로 다른 서버 URL을 수동으로 수정할 필요 없이 설정 파일에 따라 정확한 API 테스트 환경이 구축됩니다.
* **인프라 유연성 확보**: 리버스 프록시 설정을 통해 실제 클라이언트 IP를 정확히 추적할 수 있어, 추후 속도 제한(Rate Limiting)이나 보안 감사 시 정확한 데이터를 확보할 수 있습니다.
* **구성 관리 효율성**: 쿠키와 API 문서 설정을 중앙화하여 유지보수 시 설정 누락으로 인한 보안 사고를 예방합니다.
