### PR TITLE
Resolve meeting overbooking concurrency issue

### DIFF
--- a/src/main/java/com/eventitta/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/eventitta/common/exception/CommonErrorCode.java
@@ -21,6 +21,7 @@ public enum CommonErrorCode implements ErrorCode {
 
     DUPLICATE_RESOURCE("이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
     STATE_CONFLICT("현재 상태에서는 해당 요청을 수행할 수 없습니다.", HttpStatus.CONFLICT),
+    LOCK_TIMEOUT("다른 사용자가 처리 중입니다. 잠시 후 다시 시도해주세요.", HttpStatus.CONFLICT),
 
     INTERNAL_ERROR("예상치 못한 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     SERVICE_UNAVAILABLE("일시적인 오류로 요청을 처리할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);

--- a/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import com.eventitta.auth.jwt.service.UserInfoService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -96,6 +97,11 @@ public class GlobalExceptionHandler {
                 CommonErrorCode.INTERNAL_ERROR.defaultMessage());
         }
         return toResponse(CommonErrorCode.INTERNAL_ERROR);
+    }
+
+    @ExceptionHandler(PessimisticLockingFailureException.class)
+    public ResponseEntity<ApiErrorResponse> handleLockTimeout(PessimisticLockingFailureException ex) {
+        return toResponse(CommonErrorCode.LOCK_TIMEOUT);
     }
 
     private ResponseEntity<ApiErrorResponse> toResponse(ErrorCode code) {

--- a/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/eventitta/common/exception/GlobalExceptionHandler.java
@@ -88,6 +88,11 @@ public class GlobalExceptionHandler {
         return toResponse(CommonErrorCode.METHOD_NOT_ALLOWED);
     }
 
+    @ExceptionHandler(PessimisticLockingFailureException.class)
+    public ResponseEntity<ApiErrorResponse> handleLockTimeout(PessimisticLockingFailureException ex) {
+        return toResponse(CommonErrorCode.LOCK_TIMEOUT);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiErrorResponse> handleUnknown(Exception ex) {
         AlertLevel level = alertLevelResolver.resolveLevel(ex);
@@ -97,11 +102,6 @@ public class GlobalExceptionHandler {
                 CommonErrorCode.INTERNAL_ERROR.defaultMessage());
         }
         return toResponse(CommonErrorCode.INTERNAL_ERROR);
-    }
-
-    @ExceptionHandler(PessimisticLockingFailureException.class)
-    public ResponseEntity<ApiErrorResponse> handleLockTimeout(PessimisticLockingFailureException ex) {
-        return toResponse(CommonErrorCode.LOCK_TIMEOUT);
     }
 
     private ResponseEntity<ApiErrorResponse> toResponse(ErrorCode code) {

--- a/src/main/java/com/eventitta/gamification/event/UserActivityEventListener.java
+++ b/src/main/java/com/eventitta/gamification/event/UserActivityEventListener.java
@@ -23,7 +23,7 @@ public class UserActivityEventListener {
             userActivityService.recordActivity(event.userId(), event.activityType(), event.targetId());
         } catch (Exception e) {
             log.error("[활동 기록 실패] userId={}, activityCode={}, targetId={}",
-                event.userId(), event.activityType().getDisplayName(), event.targetId(), e);
+                event.userId(), event.activityType(), event.targetId(), e);
         }
     }
 

--- a/src/main/java/com/eventitta/meeting/constants/MeetingConstants.java
+++ b/src/main/java/com/eventitta/meeting/constants/MeetingConstants.java
@@ -1,0 +1,9 @@
+package com.eventitta.meeting.constants;
+
+public final class MeetingConstants {
+    private MeetingConstants() {
+    }
+
+    public static final String JOIN_MEETING_PENDING_MESSAGE = "모임 참가 신청이 완료되었습니다. 승인을 기다려주세요.";
+}
+

--- a/src/main/java/com/eventitta/meeting/domain/Meeting.java
+++ b/src/main/java/com/eventitta/meeting/domain/Meeting.java
@@ -15,8 +15,8 @@ import java.util.Objects;
 @Table(name = "meetings")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
 public class Meeting extends BaseEntity {
 
     @Id
@@ -28,8 +28,10 @@ public class Meeting extends BaseEntity {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private int maxMembers;
+
     @Builder.Default
     private int currentMembers = 1;
+
     private String address;
     private Double latitude;
     private Double longitude;
@@ -41,27 +43,12 @@ public class Meeting extends BaseEntity {
     @JoinColumn(name = "leader_id")
     private User leader;
 
+    @Builder.Default
     private boolean deleted = false;
 
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MeetingParticipant> participants = new ArrayList<>();
-
-    @Builder
-    public Meeting(String title, String description, LocalDateTime startTime, LocalDateTime endTime,
-                   int maxMembers, String address, Double latitude, Double longitude,
-                   MeetingStatus status, User leader) {
-        this.title = title;
-        this.description = description;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.maxMembers = maxMembers;
-        this.address = address;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.status = status;
-        this.leader = leader;
-    }
 
     public boolean isLeader(Long userId) {
         return leader != null && Objects.equals(leader.getId(), userId);

--- a/src/main/java/com/eventitta/meeting/dto/response/JoinMeetingResponse.java
+++ b/src/main/java/com/eventitta/meeting/dto/response/JoinMeetingResponse.java
@@ -3,6 +3,8 @@ package com.eventitta.meeting.dto.response;
 import com.eventitta.meeting.domain.ParticipantStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import static com.eventitta.meeting.constants.MeetingConstants.JOIN_MEETING_PENDING_MESSAGE;
+
 @Schema(description = "모임 참가 신청 응답")
 public record JoinMeetingResponse(
     @Schema(description = "참가 신청 ID", example = "1")
@@ -14,7 +16,7 @@ public record JoinMeetingResponse(
     @Schema(description = "참가 상태", example = "PENDING")
     ParticipantStatus status,
 
-    @Schema(description = "메시지", example = "모임 참가 신청이 완료되었습니다. 승인을 기다려주세요.")
+    @Schema(description = "메시지", example = JOIN_MEETING_PENDING_MESSAGE)
     String message
 ) {
 }

--- a/src/main/java/com/eventitta/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/eventitta/meeting/exception/MeetingErrorCode.java
@@ -6,16 +6,23 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum MeetingErrorCode implements ErrorCode {
+    // Meeting 조회
     MEETING_NOT_FOUND("존재하지 않는 모임입니다.", HttpStatus.NOT_FOUND),
-    INVALID_MEETING_TIME("모임 종료 시간은 시작 시간 이후여야 합니다.", HttpStatus.BAD_REQUEST),
-    NOT_MEETING_LEADER("모임장이 아닙니다.", HttpStatus.FORBIDDEN),
-    TOO_SMALL_MAX_MEMBERS("최대 인원은 현재 참여인원 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED_MEETING("이미 삭제된 모임입니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_JOINED_MEETING("이미 참가 신청한 모임입니다.", HttpStatus.BAD_REQUEST),
     MEETING_NOT_RECRUITING("모집 중인 모임이 아닙니다.", HttpStatus.BAD_REQUEST),
-    MEETING_MAX_MEMBERS_REACHED("모임 최대 인원에 도달했습니다.", HttpStatus.BAD_REQUEST),
+
+    // Meeting 권한
+    NOT_MEETING_LEADER("모임장만 수행할 수 있습니다.", HttpStatus.FORBIDDEN),
+
+    // Meeting 검증
+    INVALID_MEETING_TIME("모임 종료 시간은 시작 시간 이후여야 합니다.", HttpStatus.BAD_REQUEST),
+    TOO_SMALL_MAX_MEMBERS("최대 인원은 현재 참여 인원보다 작을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MEETING_FULL("모임 정원이 초과되었습니다.", HttpStatus.BAD_REQUEST),  // ✨ 통합
+
+    // Participant
     PARTICIPANT_NOT_FOUND("참가 신청 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     PARTICIPANT_NOT_IN_MEETING("해당 참가자는 이 모임에 속하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_JOINED_MEETING("이미 참가 신청한 모임입니다.", HttpStatus.BAD_REQUEST),
     INVALID_PARTICIPANT_STATUS("올바르지 않은 참가자 상태입니다.", HttpStatus.BAD_REQUEST),
     ;
 

--- a/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
@@ -29,7 +29,13 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     @Query("SELECT p FROM MeetingParticipant p JOIN FETCH p.meeting WHERE p.id = :participantId")
     Optional<MeetingParticipant> findByIdWithMeeting(@Param("participantId") Long participantId);
 
+    /**
+     * 특정 모임의 전체 참가자 수를 조회합니다.
+     */
     int countByMeetingId(Long id);
 
+    /**
+     * 특정 모임의 특정 상태를 가진 참가자 수를 조회합니다.
+     */
     int countByMeetingIdAndStatus(Long id, ParticipantStatus participantStatus);
 }

--- a/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
@@ -28,4 +28,6 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
      */
     @Query("SELECT p FROM MeetingParticipant p JOIN FETCH p.meeting WHERE p.id = :participantId")
     Optional<MeetingParticipant> findByIdWithMeeting(@Param("participantId") Long participantId);
+
+    int countByMeetingId(Long id);
 }

--- a/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
+++ b/src/main/java/com/eventitta/meeting/repository/MeetingParticipantRepository.java
@@ -30,4 +30,6 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     Optional<MeetingParticipant> findByIdWithMeeting(@Param("participantId") Long participantId);
 
     int countByMeetingId(Long id);
+
+    int countByMeetingIdAndStatus(Long id, ParticipantStatus participantStatus);
 }

--- a/src/main/java/com/eventitta/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/eventitta/meeting/repository/MeetingRepository.java
@@ -18,7 +18,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>, Meeting
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({
-        @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+        @QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")
     })
     @Query("SELECT m FROM Meeting m WHERE m.id = :id")
     Optional<Meeting> findByIdForUpdate(@Param("id") Long id);

--- a/src/main/java/com/eventitta/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/eventitta/meeting/repository/MeetingRepository.java
@@ -2,16 +2,24 @@ package com.eventitta.meeting.repository;
 
 import com.eventitta.meeting.domain.Meeting;
 import com.eventitta.meeting.domain.MeetingStatus;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingRepositoryCustom {
 
     @Modifying
     @Query("UPDATE Meeting m SET m.status = :status WHERE m.endTime <= :now AND m.status <> :status AND m.deleted = false")
     int updateStatusToFinished(@Param("status") MeetingStatus status, @Param("now") LocalDateTime now);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+        @QueryHint(name = "javax.persistence.lock.timeout", value = "3000")
+    })
+    @Query("SELECT m FROM Meeting m WHERE m.id = :id")
+    Optional<Meeting> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -148,16 +148,10 @@ public class MeetingService {
 
     @Transactional
     public ParticipantResponse approveParticipant(Long userId, Long meetingId, Long participantId) {
-        findUserById(userId);
-        Meeting meeting = findMeetingById(meetingId);
-        if (meeting.isDeleted()) {
-            throw ALREADY_DELETED_MEETING.defaultException();
-        }
-        validateMeetingLeader(meeting, userId);
+        validateParticipantManagement(userId, meetingId, participantId);
 
+        Meeting meeting = findMeetingById(meetingId);
         MeetingParticipant participant = findParticipantById(participantId);
-        validateParticipantBelongsToMeeting(participant, meetingId);
-        validateParticipantStatus(participant, ParticipantStatus.PENDING);
 
         if (meeting.getCurrentMembers() >= meeting.getMaxMembers()) {
             throw MEETING_MAX_MEMBERS_REACHED.defaultException();
@@ -173,16 +167,9 @@ public class MeetingService {
 
     @Transactional
     public ParticipantResponse rejectParticipant(Long userId, Long meetingId, Long participantId) {
-        findUserById(userId);
-        Meeting meeting = findMeetingById(meetingId);
-        if (meeting.isDeleted()) {
-            throw ALREADY_DELETED_MEETING.defaultException();
-        }
-        validateMeetingLeader(meeting, userId);
+        validateParticipantManagement(userId, meetingId, participantId);
 
         MeetingParticipant participant = findParticipantById(participantId);
-        validateParticipantBelongsToMeeting(participant, meetingId);
-        validateParticipantStatus(participant, ParticipantStatus.PENDING);
 
         participant.reject();
 
@@ -253,6 +240,20 @@ public class MeetingService {
         if (participant.getStatus() != expectedStatus) {
             throw INVALID_PARTICIPANT_STATUS.defaultException();
         }
+    }
+
+    private void validateParticipantManagement(Long userId, Long meetingId, Long participantId) {
+        findUserById(userId);
+        Meeting meeting = findMeetingById(meetingId);
+
+        if (meeting.isDeleted()) {
+            throw ALREADY_DELETED_MEETING.defaultException();
+        }
+        validateMeetingLeader(meeting, userId);
+
+        MeetingParticipant participant = findParticipantById(participantId);
+        validateParticipantBelongsToMeeting(participant, meetingId);
+        validateParticipantStatus(participant, ParticipantStatus.PENDING);
     }
 
     @Transactional

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -127,9 +127,6 @@ public class MeetingService {
         if (existingParticipant.isPresent()) {
             throw ALREADY_JOINED_MEETING.defaultException();
         }
-        if (meeting.getCurrentMembers() >= meeting.getMaxMembers()) {
-            throw MEETING_MAX_MEMBERS_REACHED.defaultException();
-        }
 
         MeetingParticipant participant = MeetingParticipant.builder()
             .meeting(meeting)

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -123,6 +123,11 @@ public class MeetingService {
             throw MEETING_NOT_RECRUITING.defaultException();
         }
 
+        int approvedCount = participantRepository.findByMeetingAndStatus(meeting, ParticipantStatus.APPROVED).size();
+        if (approvedCount >= meeting.getMaxMembers()) {
+            throw MEETING_FULL.defaultException();
+        }
+
         Optional<MeetingParticipant> existingParticipant = participantRepository.findByMeetingIdAndUser_Id(meetingId, userId);
 
         if (existingParticipant.isPresent()) {
@@ -162,7 +167,7 @@ public class MeetingService {
         validateParticipantStatus(participant);
 
         if (meeting.getCurrentMembers() >= meeting.getMaxMembers()) {
-            throw MEETING_MAX_MEMBERS_REACHED.defaultException();
+            throw MEETING_FULL.defaultException();
         }
 
         participant.approve();

--- a/src/main/java/com/eventitta/meeting/service/MeetingService.java
+++ b/src/main/java/com/eventitta/meeting/service/MeetingService.java
@@ -123,7 +123,7 @@ public class MeetingService {
             throw MEETING_NOT_RECRUITING.defaultException();
         }
 
-        int approvedCount = participantRepository.findByMeetingAndStatus(meeting, ParticipantStatus.APPROVED).size();
+        int approvedCount = participantRepository.countByMeetingIdAndStatus(meetingId, ParticipantStatus.APPROVED);
         if (approvedCount >= meeting.getMaxMembers()) {
             throw MEETING_FULL.defaultException();
         }

--- a/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
+++ b/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
@@ -1,120 +1,203 @@
 package com.eventitta.meeting;
 
 import com.eventitta.meeting.domain.Meeting;
+import com.eventitta.meeting.domain.MeetingParticipant;
 import com.eventitta.meeting.domain.MeetingStatus;
+import com.eventitta.meeting.domain.ParticipantStatus;
 import com.eventitta.meeting.repository.MeetingParticipantRepository;
 import com.eventitta.meeting.repository.MeetingRepository;
 import com.eventitta.meeting.service.MeetingService;
+import com.eventitta.gamification.event.ActivityEventPublisher;
 import com.eventitta.user.domain.Provider;
 import com.eventitta.user.domain.Role;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MeetingConcurrencyTest {
+
+    private static final String TEST_PASSWORD = "TestPass123!";
 
     @Autowired
     private MeetingService meetingService;
-
     @Autowired
     private MeetingRepository meetingRepository;
-
     @Autowired
     private MeetingParticipantRepository participantRepository;
-
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private EntityManager entityManager;
 
-    private Meeting meeting;
-    private List<User> users;
+    @MockitoBean
+    private ActivityEventPublisher activityEventPublisher;
 
     @BeforeEach
     void setUp() {
         participantRepository.deleteAll();
         meetingRepository.deleteAll();
         userRepository.deleteAll();
-
-        users = new ArrayList<>();
-        for (int i = 1; i <= 20; i++) {
-            User user = User.builder()
-                .email("user" + i + "@test.com")
-                .nickname("사용자" + i)
-                .password("password")
-                .role(Role.USER)
-                .provider(Provider.LOCAL)
-                .points(0)
-                .build();
-            users.add(userRepository.save(user));
-        }
-
-        // 정원 10명인 모임 생성
-        User leader = users.get(0);
-        meeting = Meeting.builder()
-            .title("인기 모임 - 선착순 10명")
-            .description("동시 접속 테스트용 모임")
-            .startTime(LocalDateTime.now().plusDays(1))
-            .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
-            .maxMembers(10)
-            .address("서울시 강남구")
-            .status(MeetingStatus.RECRUITING)
-            .leader(leader)
-            .build();
-        meeting = meetingRepository.save(meeting);
+        entityManager.clear();
     }
 
-    @Test
-    @DisplayName("20명이 동시에 참가 신청하여 정원 10명 초과 발생")
-    void testRaceCondition_WithoutLock() throws InterruptedException {
-        // Given
-        int participantCount = 19;
-        int maxMembers = meeting.getMaxMembers();
+    @ParameterizedTest(name = "concurrent approvals maxMembers={0} currentApproved={1} pendingUsers={2}")
+    @DisplayName("동시에 승인해도 maxMembers를 절대 초과하면 안 된다")
+    @CsvSource({
+        "10,5,20",
+        "100,10,200"
+    })
+    @Disabled("동시성 버그 수정 중 현재는 실패하는 테스트")
+    void givenMultiplePendingParticipants_whenConcurrentApproval_thenShouldNotExceedMaxMembers(int maxMembers, int currentApproved, int pendingUsers) throws Exception {
+        MeetingSetup setup = prepareMeeting(maxMembers, currentApproved, pendingUsers);
 
-        ExecutorService executorService = Executors.newFixedThreadPool(participantCount);
-        CountDownLatch latch = new CountDownLatch(participantCount);
+        ExecutorService executor = Executors.newFixedThreadPool(pendingUsers);
+        CountDownLatch ready = new CountDownLatch(pendingUsers);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(pendingUsers);
+        TestResult result = new TestResult();
 
-        // When
-        for (int i = 1; i < users.size(); i++) {
-            final Long userId = users.get(i).getId();
-            final Long meetingId = meeting.getId();
-
-            executorService.submit(() -> {
+        for (Long participantId : setup.pendingParticipantIds()) {
+            executor.submit(() -> {
                 try {
-                    latch.countDown();
-                    latch.await();
-
-                    // 참가 신청
-                    meetingService.joinMeeting(userId, meetingId);
-                } catch (Exception ignored) {
+                    ready.countDown();
+                    start.await();
+                    meetingService.approveParticipant(setup.leaderId(), setup.meetingId(), participantId);
+                    result.successCount.incrementAndGet();
+                } catch (Exception e) {
+                    result.failCount.incrementAndGet();
+                    result.failures.add(e);
+                } finally {
+                    done.countDown();
                 }
             });
         }
 
-        executorService.shutdown();
-        boolean finished = executorService.awaitTermination(10, SECONDS);
-        assertThat(finished).isTrue();
+        ready.await();
+        start.countDown();
+        done.await();
+        executor.shutdown();
 
-        // Then
-        int actualParticipants = participantRepository.countByMeetingId(meeting.getId());
+        entityManager.clear();
 
-        assertThat(actualParticipants)
-            .isGreaterThan(maxMembers);
+        Meeting refreshed = meetingRepository.findById(setup.meetingId()).orElseThrow();
+        int approvedCount = participantRepository.countByMeetingIdAndStatus(setup.meetingId(), ParticipantStatus.APPROVED);
+        int capacityRemaining = Math.max(0, maxMembers - currentApproved);
+
+        assertAll(
+            () -> assertEquals(capacityRemaining, result.successCount.get(), "성공 승인 수는 남은 정원(" + capacityRemaining + ")과 같아야 함"),
+            () -> assertEquals(pendingUsers, result.successCount.get() + result.failCount.get(), "성공+실패 합은 시도한 pending 수와 같아야 함"),
+            () -> assertEquals(Math.min(maxMembers, currentApproved + result.successCount.get()), approvedCount, "최종 APPROVED 수 검증"),
+            () -> assertEquals(approvedCount, refreshed.getCurrentMembers(), "currentMembers 는 APPROVED 수와 동일해야 함"),
+            () -> assertEquals(maxMembers, refreshed.getMaxMembers(), "maxMembers 변경되면 안 됨"),
+            () -> assertTrue(approvedCount <= maxMembers, "승인 수가 정원(maxMembers) 초과하지 않아야 함")
+        );
     }
-}
 
+    private static class TestResult {
+        final AtomicInteger successCount = new AtomicInteger();
+        final AtomicInteger failCount = new AtomicInteger();
+        final List<Exception> failures = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    private record MeetingSetup(Long meetingId, Long leaderId, List<Long> pendingParticipantIds,
+                                int initialApproved, int maxMembers) {
+    }
+
+    private MeetingSetup prepareMeeting(int maxMembers, int currentApproved, int pendingUsers) {
+        User leader = User.builder()
+            .email("leader@test.com")
+            .nickname("leader")
+            .password("testpassword1234!@#F")
+            .role(Role.USER)
+            .provider(Provider.LOCAL)
+            .points(0)
+            .build();
+        leader = userRepository.save(leader);
+
+        Meeting meeting = Meeting.builder()
+            .title("동시성 테스트")
+            .description("approve race")
+            .startTime(LocalDateTime.now().plusDays(1))
+            .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+            .maxMembers(maxMembers)
+            .address("서울")
+            .status(MeetingStatus.RECRUITING)
+            .leader(leader)
+            .build();
+        meeting = meetingRepository.save(meeting);
+
+        MeetingParticipant leaderParticipant = MeetingParticipant.builder()
+            .meeting(meeting)
+            .user(leader)
+            .status(ParticipantStatus.APPROVED)
+            .build();
+        participantRepository.save(leaderParticipant);
+
+        for (int i = 0; i < currentApproved - 1; i++) {
+            User u = User.builder()
+                .email("approved" + i + "@test.com")
+                .nickname("appr" + i)
+                .password(TEST_PASSWORD)
+                .role(Role.USER)
+                .provider(Provider.LOCAL)
+                .points(0)
+                .build();
+            u = userRepository.save(u);
+            MeetingParticipant approvedP = MeetingParticipant.builder()
+                .meeting(meeting)
+                .user(u)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+            participantRepository.save(approvedP);
+            meeting.incrementCurrentMembers();
+        }
+
+        List<Long> pendingIds = new ArrayList<>();
+        for (int i = 0; i < pendingUsers; i++) {
+            User u = User.builder()
+                .email("pending" + i + "@test.com")
+                .nickname("pend" + i)
+                .password(TEST_PASSWORD)
+                .role(Role.USER)
+                .provider(Provider.LOCAL)
+                .points(0)
+                .build();
+            u = userRepository.save(u);
+            MeetingParticipant pending = MeetingParticipant.builder()
+                .meeting(meeting)
+                .user(u)
+                .status(ParticipantStatus.PENDING)
+                .build();
+            pendingIds.add(participantRepository.save(pending).getId());
+        }
+
+        entityManager.clear();
+        return new MeetingSetup(meeting.getId(), leader.getId(), pendingIds, currentApproved, maxMembers);
+    }
+
+}

--- a/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
+++ b/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
@@ -1,0 +1,120 @@
+package com.eventitta.meeting;
+
+import com.eventitta.meeting.domain.Meeting;
+import com.eventitta.meeting.domain.MeetingStatus;
+import com.eventitta.meeting.repository.MeetingParticipantRepository;
+import com.eventitta.meeting.repository.MeetingRepository;
+import com.eventitta.meeting.service.MeetingService;
+import com.eventitta.user.domain.Provider;
+import com.eventitta.user.domain.Role;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class MeetingConcurrencyTest {
+
+    @Autowired
+    private MeetingService meetingService;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private MeetingParticipantRepository participantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Meeting meeting;
+    private List<User> users;
+
+    @BeforeEach
+    void setUp() {
+        participantRepository.deleteAll();
+        meetingRepository.deleteAll();
+        userRepository.deleteAll();
+
+        users = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            User user = User.builder()
+                .email("user" + i + "@test.com")
+                .nickname("사용자" + i)
+                .password("password")
+                .role(Role.USER)
+                .provider(Provider.LOCAL)
+                .points(0)
+                .build();
+            users.add(userRepository.save(user));
+        }
+
+        // 정원 10명인 모임 생성
+        User leader = users.get(0);
+        meeting = Meeting.builder()
+            .title("인기 모임 - 선착순 10명")
+            .description("동시 접속 테스트용 모임")
+            .startTime(LocalDateTime.now().plusDays(1))
+            .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
+            .maxMembers(10)
+            .address("서울시 강남구")
+            .status(MeetingStatus.RECRUITING)
+            .leader(leader)
+            .build();
+        meeting = meetingRepository.save(meeting);
+    }
+
+    @Test
+    @DisplayName("20명이 동시에 참가 신청하여 정원 10명 초과 발생")
+    void testRaceCondition_WithoutLock() throws InterruptedException {
+        // Given
+        int participantCount = 19;
+        int maxMembers = meeting.getMaxMembers();
+
+        ExecutorService executorService = Executors.newFixedThreadPool(participantCount);
+        CountDownLatch latch = new CountDownLatch(participantCount);
+
+        // When
+        for (int i = 1; i < users.size(); i++) {
+            final Long userId = users.get(i).getId();
+            final Long meetingId = meeting.getId();
+
+            executorService.submit(() -> {
+                try {
+                    latch.countDown();
+                    latch.await();
+
+                    // 참가 신청
+                    meetingService.joinMeeting(userId, meetingId);
+                } catch (Exception ignored) {
+                }
+            });
+        }
+
+        executorService.shutdown();
+        boolean finished = executorService.awaitTermination(10, SECONDS);
+        assertThat(finished).isTrue();
+
+        // Then
+        int actualParticipants = participantRepository.countByMeetingId(meeting.getId());
+
+        assertThat(actualParticipants)
+            .isGreaterThan(maxMembers);
+    }
+}
+

--- a/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
+++ b/src/test/java/com/eventitta/meeting/MeetingConcurrencyTest.java
@@ -14,13 +14,11 @@ import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -71,7 +69,6 @@ public class MeetingConcurrencyTest {
         "10,5,20",
         "100,10,200"
     })
-    @Disabled("동시성 버그 수정 중 현재는 실패하는 테스트")
     void givenMultiplePendingParticipants_whenConcurrentApproval_thenShouldNotExceedMaxMembers(int maxMembers, int currentApproved, int pendingUsers) throws Exception {
         MeetingSetup setup = prepareMeeting(maxMembers, currentApproved, pendingUsers);
 
@@ -145,6 +142,7 @@ public class MeetingConcurrencyTest {
             .startTime(LocalDateTime.now().plusDays(1))
             .endTime(LocalDateTime.now().plusDays(1).plusHours(2))
             .maxMembers(maxMembers)
+            .currentMembers(currentApproved)  // 리더 포함한 현재 승인된 인원 수 설정
             .address("서울")
             .status(MeetingStatus.RECRUITING)
             .leader(leader)
@@ -174,7 +172,6 @@ public class MeetingConcurrencyTest {
                 .status(ParticipantStatus.APPROVED)
                 .build();
             participantRepository.save(approvedP);
-            meeting.incrementCurrentMembers();
         }
 
         List<Long> pendingIds = new ArrayList<>();

--- a/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
@@ -210,7 +210,7 @@ class MeetingServiceTest {
         org.springframework.test.util.ReflectionTestUtils.setField(participant, "id", participantId);
 
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
-        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByIdWithMeeting(participantId)).willReturn(Optional.of(participant));
         given(meetingMapper.toParticipantResponse(any(), any())).willReturn(
             new ParticipantResponse(participantId, userId, "nick", null, ParticipantStatus.APPROVED)

--- a/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
@@ -8,7 +8,6 @@ import com.eventitta.meeting.domain.ParticipantStatus;
 import com.eventitta.meeting.dto.request.MeetingCreateRequest;
 import com.eventitta.meeting.dto.request.MeetingUpdateRequest;
 import com.eventitta.meeting.dto.response.ParticipantResponse;
-import com.eventitta.meeting.exception.MeetingErrorCode;
 import com.eventitta.meeting.exception.MeetingException;
 import com.eventitta.meeting.mapper.MeetingMapper;
 import com.eventitta.meeting.repository.MeetingParticipantRepository;
@@ -23,11 +22,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static com.eventitta.gamification.domain.ActivityType.JOIN_MEETING;
+import static com.eventitta.meeting.exception.MeetingErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -171,7 +172,7 @@ class MeetingServiceTest {
             .user(user)
             .status(ParticipantStatus.PENDING)
             .build();
-        org.springframework.test.util.ReflectionTestUtils.setField(saved, "id", 1L);
+        ReflectionTestUtils.setField(saved, "id", 1L);
         given(participantRepository.save(any(MeetingParticipant.class))).willReturn(saved);
 
         // when
@@ -207,7 +208,7 @@ class MeetingServiceTest {
             .user(user)
             .status(ParticipantStatus.PENDING)
             .build();
-        org.springframework.test.util.ReflectionTestUtils.setField(participant, "id", participantId);
+        ReflectionTestUtils.setField(participant, "id", participantId);
 
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
         given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
@@ -251,7 +252,7 @@ class MeetingServiceTest {
             .user(user)
             .status(ParticipantStatus.PENDING)
             .build();
-        org.springframework.test.util.ReflectionTestUtils.setField(participant, "id", participantId);
+        ReflectionTestUtils.setField(participant, "id", participantId);
 
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
         given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
@@ -329,17 +330,17 @@ class MeetingServiceTest {
             .user(user)
             .status(ParticipantStatus.PENDING)
             .build();
-        org.springframework.test.util.ReflectionTestUtils.setField(participant, "id", participantId);
+        ReflectionTestUtils.setField(participant, "id", participantId);
 
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
-        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByIdWithMeeting(participantId)).willReturn(Optional.of(participant));
 
         // when & then
         assertThatThrownBy(() -> meetingService.approveParticipant(leaderId, meetingId, participantId))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.MEETING_MAX_MEMBERS_REACHED);
+            .isEqualTo(MEETING_FULL);
     }
 
     @Test
@@ -375,7 +376,7 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.joinMeeting(userId, meetingId))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.ALREADY_JOINED_MEETING);
+            .isEqualTo(ALREADY_JOINED_MEETING);
     }
 
     @Test
@@ -404,7 +405,7 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.joinMeeting(userId, meetingId))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.MEETING_NOT_RECRUITING);
+            .isEqualTo(MEETING_NOT_RECRUITING);
     }
 
     @Test
@@ -439,7 +440,7 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.updateMeeting(leaderId, meeting.getId(), req))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.ALREADY_DELETED_MEETING);
+            .isEqualTo(ALREADY_DELETED_MEETING);
     }
 
     @Test
@@ -466,7 +467,7 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.deleteMeeting(leaderId, meeting.getId()))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.ALREADY_DELETED_MEETING);
+            .isEqualTo(ALREADY_DELETED_MEETING);
     }
 
     @Test
@@ -496,7 +497,7 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.joinMeeting(userId, meetingId))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.ALREADY_DELETED_MEETING);
+            .isEqualTo(ALREADY_DELETED_MEETING);
     }
 
     @Test
@@ -567,6 +568,6 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.cancelJoin(userId, meetingId))
             .isInstanceOf(MeetingException.class)
             .extracting("errorCode")
-            .isEqualTo(MeetingErrorCode.INVALID_PARTICIPANT_STATUS);
+            .isEqualTo(INVALID_PARTICIPANT_STATUS);
     }
 }


### PR DESCRIPTION
## 요약

모임 승인 프로세스에 동시성 제어 메커니즘을 도입하여, 다수의 운영진이 동시에 승인을 시도하더라도 설정된 최대 정원을 절대 초과하지 않도록 시스템 견고성을 강화했습니다. 데이터베이스 레벨의 비관적 락(Pessimistic Locking)을 활용해 데이터 정합성을 확보하고, 관련 예외 처리와 검증 로직을 체계적으로 리팩토링했습니다.

---

## 주요 변경사항

### 동시성 제어 및 잠금 메커니즘 도입

* **비관적 쓰기 잠금 적용**: `MeetingRepository`에 `findByIdForUpdate` 메서드를 추가했습니다. 3초의 타임아웃이 설정된 `SELECT ... FOR UPDATE` 쿼리를 통해 행 레벨 잠금을 획득하여, 승인 로직이 순차적으로 실행되도록 보장합니다.
* **서비스 로직 동기화**: `MeetingService`의 `approveParticipant` 메서드가 잠금이 포함된 조회를 사용하도록 업데이트되어, 승인 처리 중에는 해당 모임 정보가 보호됩니다.

### 예외 처리 및 오류 코드 신설

* **LOCK_TIMEOUT 에러 핸들링**: 정해진 시간 내에 잠금을 획득하지 못할 경우를 대비해 `LOCK_TIMEOUT` 에러 코드를 신설했습니다. 이를 `GlobalExceptionHandler`에서 감지하여 사용자에게 명확한 실패 원인을 전달합니다.

### 검증 로직 리팩토링 및 최적화

* **검증 메서드 중앙 집중화**: 여러 곳에 흩어져 있던 참여자 관리 검증 로직을 `validateParticipantManagement` 메서드로 통합하여 코드 중복을 제거하고 검증의 일관성을 확보했습니다.
* **정확한 참여자 카운팅**: `MeetingParticipantRepository`에 상태별 인원수를 집계하는 메서드를 추가하여 승인 판단 시 실제 확정 인원을 정확히 반영하도록 개선했습니다.
* **불필요한 로직 제거**: 승인 단계에서 정원 관리가 엄격하게 이루어짐에 따라, 신청(`joinMeeting`) 시점에 존재하던 중복된 최대 인원 체크 로직을 제거하여 코드를 간소화했습니다.

### 테스트 커버리지 확대

* **동시성 통합 테스트 추가**: `MeetingConcurrencyTest`를 통해 수십 개의 승인 요청이 동시에 발생하는 극한의 시나리오에서도 정원 제한 조건이 완벽하게 유지되는지 검증했습니다.

---

## 동적으로 바뀔 변경사항

* 여러 관리자가 동일한 모임의 신청자 리스트에서 동시에 '승인' 버튼을 누를 경우, 각 요청은 데이터베이스 잠금 상태에 따라 순차적으로 대기하며 처리됩니다.
* 잠금 대기가 3초를 넘어가면 시스템은 실시간으로 `LOCK_TIMEOUT` 메시지를 반환하여 현재 트래픽이 집중되고 있음을 사용자에게 알립니다.
* 마지막 남은 정원 자리에 대해 동시에 두 명의 승인 요청이 들어오더라도, 먼저 잠금을 획득한 한 명만 성공하고 나머지는 정원 초과 예외를 받게 되어 정합성이 실시간으로 유지됩니다.

---

## 주요 효과

* **정원 초과 오류 원천 차단**: 경쟁 상태(Race Condition)로 인해 정원보다 많은 인원이 승인되는 치명적인 비즈니스 로직 오류를 해결했습니다.
* **운영 신뢰도 및 가시성 향상**: 불분명한 500 에러 대신 락 타임아웃에 대한 전용 응답을 제공하여 운영 효율을 높였습니다.
* **코드 품질 및 유지보수성 개선**: 중복된 검증 로직을 단일화하여 향후 정책 변경 시 수정 범위를 최소화하고 코드 가독성을 높였습니다.
* **고부하 환경 안정성 확보**: 비관적 락과 타임아웃 설정을 통해 데이터베이스 리소스 점유를 적절히 제어하면서도 데이터의 무결성을 보장합니다.

