### PR TITLE
Apply fetch join to liked posts retrieval

### DIFF
--- a/src/main/java/com/eventitta/post/controller/PostController.java
+++ b/src/main/java/com/eventitta/post/controller/PostController.java
@@ -115,11 +115,11 @@ public class PostController {
         @ApiResponse(responseCode = "200", description = "본인이 추천한 게시글 목록 조회 성공"),
     })
     @GetMapping("/liked")
-    public ResponseEntity<List<PostSummaryResponse>> likedPosts(@CurrentUser Long userId) {
-        List<Post> posts = postService.getLikedPosts(userId);
-        List<PostSummaryResponse> dto = posts.stream()
-            .map(PostSummaryResponse::from)
-            .collect(Collectors.toList());
-        return ResponseEntity.ok(dto);
+    public ResponseEntity<PageResponse<PostSummaryResponse>> likedPosts(
+        @CurrentUser Long userId,
+        @Valid PostFilter filter
+    ) {
+        PageResponse<PostSummaryResponse> result = postService.getLikedPosts(userId, filter);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepository.java
@@ -2,14 +2,14 @@ package com.eventitta.post.repository;
 
 import com.eventitta.post.domain.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.List;
 
-public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+public interface PostLikeRepository extends JpaRepository<PostLike, Long>, PostLikeRepositoryCustom {
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);
 
     List<PostLike> findAllByUserId(Long userId);
-
-    long countByPostId(Long postId);
 }

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepository.java
@@ -2,11 +2,9 @@ package com.eventitta.post.repository;
 
 import com.eventitta.post.domain.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>, PostLikeRepositoryCustom {
     Optional<PostLike> findByPostIdAndUserId(Long postId, Long userId);

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepositoryCustom.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.eventitta.post.repository;
 
+import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.response.PostSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostLikeRepositoryCustom {
-    Page<PostSummaryResponse> findLikedSummaries(Long userId, Pageable pageable);
+    Page<PostSummaryResponse> findLikedSummaries(Long userId, PostFilter filter, Pageable pageable);
 }
-

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepositoryCustom.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.post.dto.response.PostSummaryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostLikeRepositoryCustom {
+    Page<PostSummaryResponse> findLikedSummaries(Long userId, Pageable pageable);
+}
+

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.eventitta.post.repository;
+
+import com.eventitta.post.dto.response.PostSummaryResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.eventitta.post.domain.QPost.post;
+import static com.eventitta.post.domain.QPostLike.postLike;
+import static com.eventitta.region.domain.QRegion.region;
+import static com.eventitta.user.domain.QUser.user;
+
+@RequiredArgsConstructor
+public class PostLikeRepositoryImpl implements PostLikeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PostSummaryResponse> findLikedSummaries(Long userId, Pageable pageable) {
+        List<PostSummaryResponse> content = queryFactory
+            .select(Projections.constructor(
+                PostSummaryResponse.class,
+                post.id,
+                post.title,
+                user.nickname,
+                region.code,
+                post.likeCount,
+                post.createdAt
+            ))
+            .from(postLike)
+            .join(postLike.post, post)
+            .join(post.user, user)
+            .join(post.region, region)
+            .where(
+                postLike.user.id.eq(userId),
+                post.deleted.isFalse()
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(post.createdAt.desc())
+            .fetch();
+
+        return PageableExecutionUtils.getPage(content, pageable,
+            () -> Optional.ofNullable(
+                queryFactory.select(post.count())
+                    .from(postLike)
+                    .join(postLike.post, post)
+                    .where(
+                        postLike.user.id.eq(userId),
+                        post.deleted.isFalse()
+                    )
+                    .fetchOne()
+            ).orElse(0L)
+        );
+    }
+}
+

--- a/src/main/java/com/eventitta/post/repository/PostLikeRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostLikeRepositoryImpl.java
@@ -1,12 +1,21 @@
 package com.eventitta.post.repository;
 
+import com.eventitta.post.dto.PostFilter;
+import com.eventitta.post.dto.SearchType;
 import com.eventitta.post.dto.response.PostSummaryResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,45 +28,113 @@ import static com.eventitta.user.domain.QUser.user;
 @RequiredArgsConstructor
 public class PostLikeRepositoryImpl implements PostLikeRepositoryCustom {
 
+    private static final String WILDCARD_FORMAT = "%%%s%%";
+    private static final String LOWER_CAST_TEMPLATE = "lower(cast({0} as string))";
+
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<PostSummaryResponse> findLikedSummaries(Long userId, Pageable pageable) {
-        List<PostSummaryResponse> content = queryFactory
-            .select(Projections.constructor(
-                PostSummaryResponse.class,
-                post.id,
-                post.title,
-                user.nickname,
-                region.code,
-                post.likeCount,
-                post.createdAt
-            ))
+    public Page<PostSummaryResponse> findLikedSummaries(Long userId, PostFilter filter, Pageable pageable) {
+        BooleanBuilder whereClause = buildWhereClause(userId, filter);
+
+        List<PostSummaryResponse> content = fetchLikedPostSummaries(whereClause, pageable);
+        Long totalCount = countLikedPosts(whereClause);
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount);
+    }
+
+    private BooleanBuilder buildWhereClause(Long userId, PostFilter filter) {
+        BooleanBuilder predicate = new BooleanBuilder()
+            .and(post.deleted.isFalse())
+            .and(postLike.user.id.eq(userId));
+
+        if (filter == null) {
+            return predicate;
+        }
+
+        applySearchFilter(predicate, filter);
+        applyRegionFilter(predicate, filter);
+
+        return predicate;
+    }
+
+    private void applySearchFilter(BooleanBuilder predicate, PostFilter filter) {
+        if (filter.searchType() == null || !StringUtils.hasText(filter.keyword())) {
+            return;
+        }
+
+        String lowercaseKeyword = filter.keyword().toLowerCase();
+        BooleanExpression searchCondition = createSearchCondition(filter.searchType(), lowercaseKeyword);
+        predicate.and(searchCondition);
+    }
+
+    private BooleanExpression createSearchCondition(SearchType searchType, String keyword) {
+        BooleanExpression titleCondition = createTitleCondition(keyword);
+        BooleanExpression contentCondition = createContentCondition(keyword);
+
+        return switch (searchType) {
+            case TITLE -> titleCondition;
+            case CONTENT -> contentCondition;
+            case TITLE_CONTENT -> titleCondition.or(contentCondition);
+        };
+    }
+
+    private BooleanExpression createTitleCondition(String keyword) {
+        return post.title.lower().like(formatLikePattern(keyword));
+    }
+
+    private BooleanExpression createContentCondition(String keyword) {
+        StringExpression loweredContent = Expressions.stringTemplate(
+            LOWER_CAST_TEMPLATE,
+            post.content
+        );
+        return loweredContent.like(formatLikePattern(keyword));
+    }
+
+    private String formatLikePattern(String keyword) {
+        return String.format(WILDCARD_FORMAT, keyword);
+    }
+
+    private void applyRegionFilter(BooleanBuilder predicate, PostFilter filter) {
+        if (filter.regionCode() != null) {
+            predicate.and(post.region.code.eq(filter.regionCode()));
+        }
+    }
+
+    private List<PostSummaryResponse> fetchLikedPostSummaries(BooleanBuilder whereClause, Pageable pageable) {
+        return queryFactory
+            .select(createPostSummaryProjection())
             .from(postLike)
             .join(postLike.post, post)
             .join(post.user, user)
             .join(post.region, region)
-            .where(
-                postLike.user.id.eq(userId),
-                post.deleted.isFalse()
-            )
+            .where(whereClause)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .orderBy(post.createdAt.desc())
             .fetch();
+    }
 
-        return PageableExecutionUtils.getPage(content, pageable,
-            () -> Optional.ofNullable(
-                queryFactory.select(post.count())
-                    .from(postLike)
-                    .join(postLike.post, post)
-                    .where(
-                        postLike.user.id.eq(userId),
-                        post.deleted.isFalse()
-                    )
-                    .fetchOne()
-            ).orElse(0L)
+    private ConstructorExpression<PostSummaryResponse> createPostSummaryProjection() {
+        return Projections.constructor(
+            PostSummaryResponse.class,
+            post.id,
+            post.title,
+            user.nickname,
+            region.code,
+            post.likeCount,
+            post.createdAt
         );
     }
-}
 
+    private Long countLikedPosts(BooleanBuilder whereClause) {
+        return Optional.ofNullable(
+            queryFactory
+                .select(post.count())
+                .from(postLike)
+                .join(postLike.post, post)
+                .where(whereClause)
+                .fetchOne()
+        ).orElse(0L);
+    }
+}

--- a/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/eventitta/post/repository/PostRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.eventitta.post.repository;
 import com.eventitta.post.domain.Post;
 import com.eventitta.post.dto.PostFilter;
 import com.eventitta.post.dto.response.PostSummaryResponse;
+import com.eventitta.region.domain.QRegion;
+import com.eventitta.user.domain.QUser;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Projections;
@@ -32,8 +34,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     public Page<Post> findAllByFilter(PostFilter filter, Pageable pageable) {
         BooleanBuilder predicate = buildFilter(filter);
 
-        com.eventitta.user.domain.QUser postUser = new com.eventitta.user.domain.QUser("postUser");
-        com.eventitta.region.domain.QRegion postRegion = new com.eventitta.region.domain.QRegion("postRegion");
+        QUser postUser = new QUser("postUser");
+        QRegion postRegion = new QRegion("postRegion");
 
         List<Post> content = queryFactory
             .selectFrom(post)
@@ -58,7 +60,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     @Override
     public Page<PostSummaryResponse> findSummaries(PostFilter filter, Pageable pageable) {
         BooleanBuilder predicate = buildFilter(filter);
-        com.eventitta.user.domain.QUser postUser = new com.eventitta.user.domain.QUser("postUser");
+        QUser postUser = new QUser("postUser");
 
         List<PostSummaryResponse> content = queryFactory
             .select(Projections.constructor(

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -158,10 +158,9 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<Post> getLikedPosts(Long userId) {
-        return postLikeRepository.findAllByUserId(userId)
-            .stream()
-            .map(PostLike::getPost)
-            .collect(Collectors.toList());
+    public PageResponse<PostSummaryResponse> getLikedPosts(Long userId, PostFilter filter) {
+        Pageable pg = PageRequest.of(filter.page(), filter.size());
+        Page<PostSummaryResponse> page = postLikeRepository.findLikedSummaries(userId, pg);
+        return PageResponse.of(page);
     }
 }

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -160,7 +160,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PageResponse<PostSummaryResponse> getLikedPosts(Long userId, PostFilter filter) {
         Pageable pg = PageRequest.of(filter.page(), filter.size());
-        Page<PostSummaryResponse> page = postLikeRepository.findLikedSummaries(userId, pg);
+        Page<PostSummaryResponse> page = postLikeRepository.findLikedSummaries(userId, filter, pg);
         return PageResponse.of(page);
     }
 }

--- a/src/test/java/com/eventitta/post/controller/PostControllerTest.java
+++ b/src/test/java/com/eventitta/post/controller/PostControllerTest.java
@@ -343,19 +343,21 @@ class PostControllerTest extends ControllerTestSupport {
 
     @Test
     @WithMockCustomUser(userId = 42L)
-    @DisplayName("본인이 추천한 게시글 목록 조회를 할 수 있다.")
-    void getLikedPosts_shouldReturnList() throws Exception {
+    @DisplayName("본인이 추천한 게시글 목록을 페이지로 조회할 수 있다.")
+    void getLikedPosts_shouldReturnPagedList() throws Exception {
         // given
-        List<Post> likedPosts = List.of(
-            Post.builder().id(1L).title("첫 글").content("내용").user(mock(User.class)).region(mock(Region.class)).build(),
-            Post.builder().id(2L).title("두 번째 글").content("내용2").user(mock(User.class)).region(mock(Region.class)).build()
-        );
-        given(postService.getLikedPosts(42L)).willReturn(likedPosts);
+        PostSummaryResponse s1 = new PostSummaryResponse(1L, "첫 글", "nick1", "1100110100", 3, LocalDateTime.now());
+        PostSummaryResponse s2 = new PostSummaryResponse(2L, "두 번째 글", "nick2", "1100110100", 5, LocalDateTime.now());
+        PageResponse<PostSummaryResponse> page = new PageResponse<>(List.of(s1, s2), 0, 10, 2, 1);
+        given(postService.getLikedPosts(eq(42L), any(PostFilter.class))).willReturn(page);
 
         // when
         mockMvc.perform(
-                get("/api/v1/posts/liked"))
+                get("/api/v1/posts/liked")
+                    .param("page", "0")
+                    .param("size", "10")
+            )
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(2));
+            .andExpect(jsonPath("$.content.length()").value(2));
     }
 }


### PR DESCRIPTION
## 요약

사용자가 좋아요를 누른 게시글 조회 기능을 단순 리스트 반환 방식에서 페이징 및 필터링이 가능한 요약 응답 구조로 개편했습니다. QueryDSL 기반의 커스텀 리포지토리를 도입하여 대량의 데이터에서도 효율적인 조회가 가능하도록 성능을 최적화했습니다.

---

## 주요 변경사항

### API 및 응답 구조 고도화

* **페이징 엔드포인트 전환**: `PostController`의 `/liked` API 응답 타입을 `List`에서 `PageResponse<PostSummaryResponse>`로 변경했습니다. 이를 통해 클라이언트는 대량의 데이터 중 필요한 부분만 효율적으로 수신할 수 있습니다.
* **검색 필터 도입**: 조회 시 `PostFilter` 객체를 인자로 받아, 사용자가 좋아요를 누른 게시글 중에서도 특정 조건(지역, 키워드 등)에 맞는 항목만 필터링하여 볼 수 있도록 기능을 확장했습니다.

### 리포지토리 아키텍처 개선

* **QueryDSL 커스텀 리포지토리 구현**: `PostLikeRepositoryCustom` 인터페이스와 이를 구현한 `PostLikeRepositoryImpl`을 추가했습니다. 복잡한 조인(Join)과 동적 쿼리가 포함된 페이징 로직을 QueryDSL로 작성하여 가독성과 유지보수성을 높였습니다.
* **리포지토리 상속 구조 업데이트**: `PostLikeRepository`가 새로 만든 커스텀 인터페이스를 상속받도록 수정하여, 기존 기능과 QueryDSL 쿼리 로직을 통합했습니다.

### 코드 품질 및 정합성 강화

* **Q-Class 참조 최적화**: `PostRepositoryImpl` 내에서 사용되는 `QUser`, `QRegion` 등의 QueryDSL 클래스 참조 방식을 일관성 있게 정리하여 코드의 가독성을 개선했습니다.
* **컨트롤러 테스트 동기화**: 변경된 페이징 구조와 필터 파라미터가 API 레벨에서 정상적으로 작동하는지 검증하는 테스트 코드를 업데이트했습니다.

---

**동적으로 바뀔 변경사항**

* 클라이언트가 전달하는 `Pageable` 파라미터(페이지 번호, 사이즈)에 따라 데이터베이스에서 조회해 오는 레코드의 범위와 오프셋이 실시간으로 계산됩니다.
* `PostFilter`에 입력되는 검색 조건의 유무에 따라 QueryDSL이 동적으로 쿼리문을 생성하여, 조건이 있을 때만 `WHERE` 절을 추가하는 방식으로 작동합니다.

---

## 주요 효과

* **성능 최적화 및 리소스 절감**: 모든 좋아요 목록을 한 번에 메모리에 로드하던 방식에서 페이징 방식으로 전환하여 서버의 메모리 부하를 줄이고 데이터베이스 응답 속도를 향상시켰습니다.
* **사용자 편의성 증대**: 필터 기능을 통해 자신이 좋아요를 누른 수많은 게시글 중에서 원하는 정보를 더 빠르게 찾을 수 있는 검색 환경을 제공합니다.
* **유지보수성 향상**: 커스텀 리포지토리 패턴을 적용하여 JPA 기본 기능으로 구현하기 어려운 복잡한 동적 조회 로직을 도메인 로직과 분리하여 깔끔하게 관리할 수 있게 되었습니다.