### PR TITLE
Fix badge N+1 query issue

### DIFF
--- a/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
+++ b/src/main/java/com/eventitta/gamification/domain/BadgeRule.java
@@ -25,6 +25,10 @@ public class BadgeRule extends BaseTimeEntity {
     @Column(name = "activity_type", nullable = false, length = 50)
     private ActivityType activityType;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "evaluation_type", nullable = false, length = 20)
+    private EvaluationType evaluationType;
+
     @Column(nullable = false)
     private int threshold;
 
@@ -32,10 +36,11 @@ public class BadgeRule extends BaseTimeEntity {
     private boolean enabled;
 
     @Builder
-    public BadgeRule(Long id, Badge badge, ActivityType activityType, int threshold, boolean enabled) {
+    public BadgeRule(Long id, Badge badge, ActivityType activityType, EvaluationType evaluationType, int threshold, boolean enabled) {
         this.id = id;
         this.badge = badge;
         this.activityType = activityType;
+        this.evaluationType = evaluationType;
         this.threshold = threshold;
         this.enabled = enabled;
     }

--- a/src/main/java/com/eventitta/gamification/domain/EvaluationType.java
+++ b/src/main/java/com/eventitta/gamification/domain/EvaluationType.java
@@ -1,0 +1,6 @@
+package com.eventitta.gamification.domain;
+
+public enum EvaluationType {
+    COUNT,   // 활동 횟수 기준
+    POINTS   // 획득 포인트 합계 기준
+}

--- a/src/main/java/com/eventitta/gamification/dto/projection/ActivitySummaryProjection.java
+++ b/src/main/java/com/eventitta/gamification/dto/projection/ActivitySummaryProjection.java
@@ -6,4 +6,6 @@ public interface ActivitySummaryProjection {
     ActivityType getActivityType();
 
     long getCount();
+
+    long getTotalPoints();
 }

--- a/src/main/java/com/eventitta/gamification/dto/response/ActivitySummaryResponse.java
+++ b/src/main/java/com/eventitta/gamification/dto/response/ActivitySummaryResponse.java
@@ -2,9 +2,10 @@ package com.eventitta.gamification.dto.response;
 
 public record ActivitySummaryResponse(
     String activityType,
-    long count
+    long count,
+    long totalPoints
 ) {
-    public static ActivitySummaryResponse from(String activityType, long count) {
-        return new ActivitySummaryResponse(activityType, count);
+    public static ActivitySummaryResponse from(String activityType, long count, long totalPoints) {
+        return new ActivitySummaryResponse(activityType, count, totalPoints);
     }
 }

--- a/src/main/java/com/eventitta/gamification/evaluator/ActivityCountRuleEvaluator.java
+++ b/src/main/java/com/eventitta/gamification/evaluator/ActivityCountRuleEvaluator.java
@@ -1,29 +1,24 @@
 package com.eventitta.gamification.evaluator;
 
+import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.domain.BadgeRule;
-import com.eventitta.gamification.repository.UserActivityRepository;
+import com.eventitta.gamification.domain.EvaluationType;
 import com.eventitta.user.domain.User;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 public class ActivityCountRuleEvaluator implements BadgeRuleEvaluator {
 
-    private final UserActivityRepository userActivityRepository;
-
-    public ActivityCountRuleEvaluator(UserActivityRepository repo) {
-        this.userActivityRepository = repo;
-    }
-
     @Override
     public boolean supports(BadgeRule rule) {
-        return rule.getActivityType() != null;
+        return rule.getActivityType() != null && rule.getEvaluationType() == EvaluationType.COUNT;
     }
 
     @Override
-    public boolean isSatisfied(User user, BadgeRule rule) {
-        long count = userActivityRepository.countByUserIdAndActivityType(
-            user.getId(), rule.getActivityType()
-        );
+    public boolean isSatisfied(User user, BadgeRule rule, Map<ActivityType, Long> activityCountMap, Map<ActivityType, Long> activityPointsMap) {
+        long count = activityCountMap.getOrDefault(rule.getActivityType(), 0L);
         return count >= rule.getThreshold();
     }
 }

--- a/src/main/java/com/eventitta/gamification/evaluator/ActivityPointsRuleEvaluator.java
+++ b/src/main/java/com/eventitta/gamification/evaluator/ActivityPointsRuleEvaluator.java
@@ -1,0 +1,24 @@
+package com.eventitta.gamification.evaluator;
+
+import com.eventitta.gamification.domain.ActivityType;
+import com.eventitta.gamification.domain.BadgeRule;
+import com.eventitta.gamification.domain.EvaluationType;
+import com.eventitta.user.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ActivityPointsRuleEvaluator implements BadgeRuleEvaluator {
+
+    @Override
+    public boolean supports(BadgeRule rule) {
+        return rule.getActivityType() != null && rule.getEvaluationType() == EvaluationType.POINTS;
+    }
+
+    @Override
+    public boolean isSatisfied(User user, BadgeRule rule, Map<ActivityType, Long> activityCountMap, Map<ActivityType, Long> activityPointsMap) {
+        long totalPoints = activityPointsMap.getOrDefault(rule.getActivityType(), 0L);
+        return totalPoints >= rule.getThreshold();
+    }
+}

--- a/src/main/java/com/eventitta/gamification/evaluator/BadgeRuleEvaluator.java
+++ b/src/main/java/com/eventitta/gamification/evaluator/BadgeRuleEvaluator.java
@@ -1,10 +1,13 @@
 package com.eventitta.gamification.evaluator;
 
+import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.domain.BadgeRule;
 import com.eventitta.user.domain.User;
+
+import java.util.Map;
 
 public interface BadgeRuleEvaluator {
     boolean supports(BadgeRule rule);
 
-    boolean isSatisfied(User user, BadgeRule rule);
+    boolean isSatisfied(User user, BadgeRule rule, Map<ActivityType, Long> activityCountMap, Map<ActivityType, Long> activityPointsMap);
 }

--- a/src/main/java/com/eventitta/gamification/repository/BadgeRuleRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/BadgeRuleRepository.java
@@ -2,6 +2,14 @@ package com.eventitta.gamification.repository;
 
 import com.eventitta.gamification.domain.BadgeRule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BadgeRuleRepository extends JpaRepository<BadgeRule, Long> {
+
+    @Query("SELECT br FROM BadgeRule br " +
+        "JOIN FETCH br.badge " +
+        "WHERE br.enabled = true")
+    List<BadgeRule> findAllEnabledWithBadge();
 }

--- a/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserActivityRepository.java
@@ -13,7 +13,9 @@ import java.util.List;
 public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
     long countByUserIdAndActivityType(Long userId, ActivityType activityTypeId);
 
-    @Query("SELECT ua.activityType AS activityType, COUNT(ua) AS count " +
+    @Query("SELECT ua.activityType AS activityType, " +
+        "COUNT(ua) AS count, " +
+        "SUM(ua.pointsEarned) AS totalPoints " +
         "FROM UserActivity ua " +
         "WHERE ua.userId = :userId " +
         "GROUP BY ua.activityType")
@@ -21,7 +23,6 @@ public interface UserActivityRepository extends JpaRepository<UserActivity, Long
 
     long deleteByUserIdAndActivityTypeAndTargetId(Long userId, ActivityType activityTypeId, Long targetId);
 
-    // 오늘 특정 활동이 이미 기록되었는지 확인
     @Query("SELECT COUNT(ua) > 0 FROM UserActivity ua " +
         "WHERE ua.userId = :userId " +
         "AND ua.activityType = :activityType " +

--- a/src/main/java/com/eventitta/gamification/repository/UserBadgeRepository.java
+++ b/src/main/java/com/eventitta/gamification/repository/UserBadgeRepository.java
@@ -2,7 +2,14 @@ package com.eventitta.gamification.repository;
 
 import com.eventitta.gamification.domain.UserBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Set;
 
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
     boolean existsByUserIdAndBadgeId(Long userId, Long badgeId);
+
+    @Query("SELECT ub.badge.id FROM UserBadge ub WHERE ub.user.id = :userId")
+    Set<Long> findBadgeIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/eventitta/user/controller/UserController.java
+++ b/src/main/java/com/eventitta/user/controller/UserController.java
@@ -85,7 +85,11 @@ public class UserController {
     @GetMapping("/me/activities")
     public ResponseEntity<List<ActivitySummaryResponse>> getMyActivitySummary(@CurrentUser Long userId) {
         List<ActivitySummaryResponse> result = userActivityService.getActivitySummaryProjection(userId).stream()
-            .map(summary -> new ActivitySummaryResponse(summary.getActivityType().toString(), summary.getCount()))
+            .map(summary -> new ActivitySummaryResponse(
+                summary.getActivityType().toString(),
+                summary.getCount(),
+                summary.getTotalPoints()
+            ))
             .toList();
         return ResponseEntity.ok(result);
     }

--- a/src/main/resources/db/migration/V10__Add_evaluation_type_to_badge_rules.sql
+++ b/src/main/resources/db/migration/V10__Add_evaluation_type_to_badge_rules.sql
@@ -1,0 +1,8 @@
+-- Add evaluation_type column to badge_rules table
+ALTER TABLE badge_rules ADD COLUMN evaluation_type VARCHAR(20) NOT NULL DEFAULT 'COUNT';
+
+-- Update existing records to use COUNT as default
+UPDATE badge_rules SET evaluation_type = 'COUNT' WHERE evaluation_type IS NULL;
+
+-- Add comment for clarity
+COMMENT ON COLUMN badge_rules.evaluation_type IS 'Badge evaluation type: COUNT (activity count) or POINTS (total points)';

--- a/src/test/java/com/eventitta/gamification/service/BadgeServiceTest.java
+++ b/src/test/java/com/eventitta/gamification/service/BadgeServiceTest.java
@@ -5,7 +5,6 @@ import com.eventitta.gamification.domain.Badge;
 import com.eventitta.gamification.domain.BadgeRule;
 import com.eventitta.gamification.domain.EvaluationType;
 import com.eventitta.gamification.domain.UserBadge;
-import com.eventitta.gamification.dto.projection.ActivitySummaryProjection;
 import com.eventitta.gamification.evaluator.BadgeRuleEvaluator;
 import com.eventitta.gamification.repository.BadgeRuleRepository;
 import com.eventitta.gamification.repository.UserActivityRepository;
@@ -18,7 +17,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static com.eventitta.gamification.domain.ActivityType.CREATE_COMMENT;
 import static com.eventitta.gamification.domain.ActivityType.CREATE_POST;


### PR DESCRIPTION

## 요약

게이미피케이션 시스템에 다중 뱃지 평가 타입을 도입하여, 뱃지 수여 조건을 '단순 활동 횟수'뿐만 아니라 '누적 포인트' 기준으로도 설정할 수 있도록 고도화했습니다. 이를 통해 사용자에게 더욱 정교하고 다양한 보상 체계를 제공할 수 있는 기반을 마련했습니다.

---

## 주요 변경사항

### 뱃지 평가 로직 및 모델 강화

* **EvaluationType 도입**: 뱃지 규칙(`BadgeRule`)에 `COUNT`(횟수)와 `POINTS`(포인트) 중 하나를 선택할 수 있는 평가 타입을 추가했습니다.
* **평가 엔진(Evaluator) 확장**: 포인트 기반 평가를 담당하는 `ActivityPointsRuleEvaluator`를 신설하고, 기존 횟수 기반 로직을 인터페이스(`BadgeRuleEvaluator`) 기반의 전략 패턴으로 리팩토링하여 확장성을 확보했습니다.

### 서비스 및 리포지토리 최적화

* **효율적인 뱃지 수여 로직**: `BadgeService`에서 뱃지 규칙을 가져올 때 활성화된 규칙만 필터링하고, 사용자가 이미 보유한 뱃지를 사전에 체크하여 불필요한 연산을 줄였습니다.
* **최적화된 쿼리 추가**: 특정 사용자가 보유한 뱃지 ID 목록을 한 번에 조회하는 `findBadgeIdsByUserId` 등을 추가하여 데이터베이스 I/O 효율을 높였습니다.

### 활동 요약 및 프로젝션 개선

* **복합 지표 집계**: 활동 요약(`ActivitySummary`) 프로젝션에 횟수와 포인트 합계를 모두 포함시켜, 한 번의 쿼리로 두 가지 평가 지표를 모두 확보할 수 있도록 개선했습니다.

### 데이터베이스 및 마이그레이션

* **하위 호환성 유지**: `badge_rules` 테이블에 `evaluation_type` 컬럼을 추가하고, 기존 데이터는 모두 `COUNT`로 기본값을 설정하여 시스템의 연속성을 보장했습니다.

---

**동적으로 바뀔 변경사항**

* 뱃지 규칙을 생성하거나 수정할 때 선택한 `EvaluationType`에 따라, 뱃지 수여 시점에 작동하는 평가 알고리즘이 실시간으로 교체됩니다.
* 사용자가 활동을 기록할 때마다 횟수와 포인트가 동시에 집계되며, 이 데이터가 프로젝션을 통해 평가 엔진에 실시간으로 전달되어 뱃지 획득 여부를 결정합니다.

---

## 주요 효과

* **보상 체계의 다양화**: "10번 참여"와 같은 양적 보상뿐만 아니라 "누적 1,000포인트 달성"과 같은 질적/성과 중심의 보상이 가능해졌습니다.
* **시스템 성능 및 정확도 향상**: 리포지토리 메서드 최적화와 사전 중복 체크 로직을 통해 대규모 사용자 환경에서도 안정적인 뱃지 수여가 가능합니다.
* **유지보수성 및 확장성 극대화**: 전략 패턴 도입으로 향후 "연속 출석"이나 "특정 기간 활동" 등 새로운 평가 방식이 추가되더라도 기존 코드의 수정 없이 확장이 가능합니다.

