### PR TITLE
Simplify Activity creation factory and resolve circular dependency

### DIFF
--- a/src/main/java/com/eventitta/gamification/domain/ActivityType.java
+++ b/src/main/java/com/eventitta/gamification/domain/ActivityType.java
@@ -26,12 +26,9 @@ public enum ActivityType {
     private final ResourceType resourceType;
 
     public UserActivity createActivity(Long userId, Long targetId) {
-        return switch (this.resourceType) {
-            case POST -> UserActivity.forPost(userId, this, targetId);
-            case COMMENT -> UserActivity.forComment(userId, this, targetId);
-            case MEETING -> UserActivity.forMeeting(userId, this, targetId);
-            case SYSTEM -> UserActivity.forSystem(userId, this);
-            case UNKNOWN -> UserActivity.forUnknown(userId, this);
-        };
+        if (this.resourceType == SYSTEM) {
+            return UserActivity.forSystem(userId, this);
+        }
+        return UserActivity.of(userId, this, targetId);
     }
 }

--- a/src/main/java/com/eventitta/gamification/domain/UserActivity.java
+++ b/src/main/java/com/eventitta/gamification/domain/UserActivity.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static com.eventitta.gamification.domain.ResourceType.*;
-
 @Getter
 @Builder
 @NoArgsConstructor
@@ -18,7 +16,6 @@ import static com.eventitta.gamification.domain.ResourceType.*;
 public class UserActivity extends BaseTimeEntity {
 
     private static final Long SYSTEM_TARGET_ID = 0L;
-    private static final Long UNKNOWN_TARGET_ID = 0L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,53 +48,7 @@ public class UserActivity extends BaseTimeEntity {
             .build();
     }
 
-    public static UserActivity forPost(Long userId, ActivityType activityType, Long postId) {
-        return UserActivity.builder()
-            .userId(userId)
-            .activityType(activityType)
-            .resourceType(POST)
-            .targetId(postId)
-            .pointsEarned(activityType.getDefaultPoint())
-            .build();
-    }
-
-    public static UserActivity forComment(Long userId, ActivityType activityType, Long commentId) {
-        return UserActivity.builder()
-            .userId(userId)
-            .activityType(activityType)
-            .resourceType(COMMENT)
-            .targetId(commentId)
-            .pointsEarned(activityType.getDefaultPoint())
-            .build();
-    }
-
-    public static UserActivity forMeeting(Long userId, ActivityType activityType, Long meetingId) {
-        return UserActivity.builder()
-            .userId(userId)
-            .activityType(activityType)
-            .resourceType(MEETING)
-            .targetId(meetingId)
-            .pointsEarned(activityType.getDefaultPoint())
-            .build();
-    }
-
     public static UserActivity forSystem(Long userId, ActivityType activityType) {
-        return UserActivity.builder()
-            .userId(userId)
-            .activityType(activityType)
-            .resourceType(SYSTEM)
-            .targetId(SYSTEM_TARGET_ID)
-            .pointsEarned(activityType.getDefaultPoint())
-            .build();
-    }
-
-    public static UserActivity forUnknown(Long userId, ActivityType activityType) {
-        return UserActivity.builder()
-            .userId(userId)
-            .activityType(activityType)
-            .resourceType(UNKNOWN)
-            .targetId(UNKNOWN_TARGET_ID)
-            .pointsEarned(0)
-            .build();
+        return of(userId, activityType, SYSTEM_TARGET_ID);
     }
 }


### PR DESCRIPTION

## 요약

게이미피케이션 시스템에서 사용자 활동(`UserActivity`) 객체를 생성하는 방식을 더 범용적이고 단순한 구조로 개편했습니다. 파편화되어 있던 도메인별 생성 메서드들을 하나의 범용 메서드로 통합하여 코드 중복을 줄이고 유지보수성을 높였습니다.

---

## 주요 변경사항

### 활동 생성 로직의 단순화 및 리팩토링

* **`ActivityType` 로직 최적화**: 기존의 복잡한 `switch` 문을 제거하고 조건부 로직으로 간소화했습니다. 이제 시스템 활동(System Activity)은 전용 메서드를 사용하고, 그 외 모든 일반 활동은 범용 생성 메서드를 호출하도록 통합되었습니다.
* **팩토리 메서드 통합 및 제거**: `UserActivity` 클래스 내에 존재하던 도메인별 메서드(`forPost`, `forComment`, `forMeeting`, `forUnknown`)를 모두 삭제했습니다. 대신 이들의 로직을 `of()`라는 하나의 범용 메서드로 응집시켜 객체 생성 책임을 단일화했습니다.
* **시스템 활동 생성 방식 개선**: `forSystem` 메서드가 직접 객체를 생성하는 대신 범용 `of()` 메서드에 고정된 대상 ID를 전달하는 방식으로 수정되어 코드 중복을 방지했습니다.

### 코드 클린업

* **불필요한 리소스 제거**: `UserActivity.java`에서 더 이상 사용하지 않는 리소스 타입의 정적 임포트(static import)를 제거했습니다.
* **상수 정리**: 객체 생성 로직이 범용화됨에 따라 불필요해진 `UNKNOWN_TARGET_ID` 상수를 삭제하여 코드 베이스를 정돈했습니다.

---

**동적으로 바뀔 변경사항**

* 새로운 활동 타입이나 리소스 타입이 추가되더라도 `UserActivity`에 매번 새로운 생성 메서드를 추가할 필요 없이, 공통 `of()` 메서드를 통해 유연하게 대응할 수 있게 됩니다.
* `ActivityType`에서 활동을 생성할 때, 런타임에 결정되는 타입에 따라 범용 메서드 호출 여부가 동적으로 결정되어 실행 흐름이 제어됩니다.

---

## 주요 효과

* **코드 유지보수성 향상**: 객체 생성 로직이 한곳으로 모이면서 향후 필드 추가나 생성 규칙 변경 시 수정 범위가 최소화됩니다.
* **가독성 및 응집도 개선**: 복잡한 분기문과 여러 개의 팩토리 메서드가 사라짐에 따라 게이미피케이션 서비스 전반의 코드가 간결해졌습니다.
* **실수 방지**: 도메인마다 서로 다른 생성 메서드를 찾아 써야 했던 번거로움이 사라져 개발 과정에서의 실수를 줄일 수 있습니다.

