### PR TITLE
Standardize exception handling using Error Code Enum factory

### DIFF
--- a/src/main/java/com/eventitta/auth/service/TokenService.java
+++ b/src/main/java/com/eventitta/auth/service/TokenService.java
@@ -13,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
+import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,7 +26,7 @@ public class TokenService {
 
     public TokenResponse issueTokens(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+            .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
         String at = tokenProvider.createAccessToken(userId, user.getEmail(), user.getRole().name());
         String rt = tokenProvider.createRefreshToken();

--- a/src/main/java/com/eventitta/comment/service/CommentService.java
+++ b/src/main/java/com/eventitta/comment/service/CommentService.java
@@ -1,15 +1,11 @@
 package com.eventitta.comment.service;
 
-import com.eventitta.auth.exception.AuthException;
 import com.eventitta.comment.domain.Comment;
 import com.eventitta.comment.dto.projection.CommentFlatProjection;
 import com.eventitta.comment.dto.response.CommentWithChildrenResponse;
-import com.eventitta.comment.exception.CommentException;
 import com.eventitta.comment.repository.CommentRepository;
-import com.eventitta.gamification.domain.ActivityType;
 import com.eventitta.gamification.event.ActivityEventPublisher;
 import com.eventitta.post.domain.Post;
-import com.eventitta.post.exception.PostException;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
@@ -44,14 +40,14 @@ public class CommentService {
             userId, postId, parentCommentId);
 
         Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(NOT_FOUND_POST_ID));
+            .orElseThrow(NOT_FOUND_POST_ID::defaultException);
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AuthException(NOT_FOUND_USER_ID));
+            .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
         Comment parent = null;
         if (parentCommentId != null) {
             parent = commentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new CommentException(NOT_FOUND_COMMENT_ID));
+                .orElseThrow(NOT_FOUND_COMMENT_ID::defaultException);
         }
 
         Comment comment = Comment.builder()
@@ -87,12 +83,12 @@ public class CommentService {
         log.info("[댓글 수정 시작] userId={}, commentId={}", userId, commentId);
 
         Comment comment = commentRepository.findById(commentId)
-            .orElseThrow(() -> new CommentException(NOT_FOUND_COMMENT_ID));
+            .orElseThrow(NOT_FOUND_COMMENT_ID::defaultException);
 
         if (!comment.getUser().getId().equals(userId)) {
             log.warn("[댓글 수정 권한 없음] userId={}, commentId={}, ownerId={}",
                 userId, commentId, comment.getUser().getId());
-            throw new CommentException(NO_AUTHORITY_TO_MODIFY_COMMENT);
+            throw NO_AUTHORITY_TO_MODIFY_COMMENT.defaultException();
         }
 
         comment.updateContent(content);
@@ -104,12 +100,12 @@ public class CommentService {
         log.info("[댓글 삭제 시작] userId={}, commentId={}", userId, commentId);
 
         Comment comment = commentRepository.findById(commentId)
-            .orElseThrow(() -> new CommentException(NOT_FOUND_COMMENT_ID));
+            .orElseThrow(NOT_FOUND_COMMENT_ID::defaultException);
 
         if (!comment.getUser().getId().equals(userId)) {
             log.warn("[댓글 삭제 권한 없음] userId={}, commentId={}, ownerId={}",
                 userId, commentId, comment.getUser().getId());
-            throw new CommentException(NO_AUTHORITY_TO_MODIFY_COMMENT);
+            throw NO_AUTHORITY_TO_MODIFY_COMMENT.defaultException();
         }
         comment.softDelete();
         activityEventPublisher.publishRevoke(DELETE_COMMENT, userId, commentId);

--- a/src/main/java/com/eventitta/post/service/PostService.java
+++ b/src/main/java/com/eventitta/post/service/PostService.java
@@ -1,7 +1,5 @@
 package com.eventitta.post.service;
 
-import com.eventitta.auth.exception.AuthErrorCode;
-import com.eventitta.auth.exception.AuthException;
 import com.eventitta.comment.repository.CommentRepository;
 import com.eventitta.common.response.PageResponse;
 import com.eventitta.gamification.event.ActivityEventPublisher;
@@ -16,7 +14,6 @@ import com.eventitta.post.dto.response.PostDetailResponse;
 import com.eventitta.post.dto.response.PostSummaryResponse;
 import com.eventitta.post.event.PostDeleteEventPublisher;
 import com.eventitta.post.event.PostDeletedEvent;
-import com.eventitta.post.exception.PostException;
 import com.eventitta.post.repository.PostLikeRepository;
 import com.eventitta.post.repository.PostRepository;
 import com.eventitta.region.domain.Region;
@@ -159,9 +156,9 @@ public class PostService {
     @Transactional
     public void toggleLike(Long postId, Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND_USER_ID));
+            .orElseThrow(NOT_FOUND_USER_ID::defaultException);
         Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(NOT_FOUND_POST_ID));
+            .orElseThrow(NOT_FOUND_POST_ID::defaultException);
 
         Optional<PostLike> existing = postLikeRepository.findByPostIdAndUserId(postId, userId);
         if (existing.isPresent()) {


### PR DESCRIPTION
## 요약

`TokenService`, `CommentService`, `PostService` 전반에 걸쳐 예외 발생 로직을 표준화했습니다. 예외 객체를 직접 생성하는 대신 에러 코드 Enum에서 제공하는 `defaultException()` 메서드를 사용하도록 변경하여, 코드의 일관성을 높이고 보일러플레이트를 획기적으로 줄였습니다.

## 주요 변경사항

* **예외 처리 로직 표준화**: `TokenService`, `CommentService`, `PostService`에서 사용자, 게시글, 댓글을 찾지 못했을 때 발생하는 예외 처리를 Enum 기반의 `defaultException()` 호출 방식으로 전환했습니다.
* **코드 클린업 및 최적화**: 예외 생성 방식이 변경됨에 따라 더 이상 사용되지 않는 예외 클래스의 임포트(import) 구문을 제거하여 코드베이스를 정돈했습니다.
* **가독성 및 일관성 향상**: `TokenService`에 `NOT_FOUND_USER_ID` 등의 정적 임포트(static import)를 적용하여 코드의 가독성을 높이고 명확한 의도 전달이 가능하게 했습니다.

---

**동적으로 바뀔 변경사항**

* 각 서비스에서 예외가 발생할 때, 해당 도메인의 에러 코드 Enum에 정의된 메시지와 상태 코드에 따라 예외 객체가 동적으로 생성되어 투척됩니다.
* 에러 메시지나 상태 코드를 변경해야 할 경우, 서비스 로직을 수정할 필요 없이 Enum 클래스만 업데이트하면 모든 관련 서비스에 즉시 반영됩니다.

---

## 주요 효과

* **유지보수 효율성 극대화**: 예외 생성 로직이 Enum 내부에 캡슐화되어 있어, 예외 처리 전략이 변경되더라도 수정 범위를 최소화할 수 있습니다.
* **보일러플레이트 제거**: 반복적인 `new CustomException(ErrorCode.XYZ)` 패턴을 제거하여 비즈니스 로직 본연의 가독성을 확보했습니다.
* **도메인 간 일관성 확보**: 여러 서비스에서 동일한 에러 코드에 대해 서로 다른 예외를 던지는 실수를 방지하고, 전역적으로 일관된 예외 처리 흐름을 보장합니다.

