### PR TITLE
Add Jackson XML library and resolve single object deserialization issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
+    // xml 파싱 - 단일 객체 파싱 이슈
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
     // Flyway 의존성
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/com/eventitta/festivals/dto/external/seoul/SeoulFestivalResponse.java
+++ b/src/main/java/com/eventitta/festivals/dto/external/seoul/SeoulFestivalResponse.java
@@ -2,6 +2,7 @@ package com.eventitta.festivals.dto.external.seoul;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 
 import java.util.List;
 

--- a/src/main/java/com/eventitta/festivals/dto/external/seoul/SeoulFestivalResponse.java
+++ b/src/main/java/com/eventitta/festivals/dto/external/seoul/SeoulFestivalResponse.java
@@ -14,6 +14,7 @@ public record SeoulFestivalResponse(
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record CulturalEventInfo(
         @JsonProperty("row")
+        @JacksonXmlElementWrapper(useWrapping = false)
         List<SeoulFestivalRow> row
     ) {
     }


### PR DESCRIPTION
## 요약

SeoulFestivalResponse DTO의 XML 역직렬화(Deserialization) 로직을 개선하여 데이터 매핑의 정확도를 높였습니다.

## 주요 변경사항

* SeoulFestivalResponse.java 내 CulturalEventInfo 레코드 수정: row 리스트 필드에 @JacksonXmlElementWrapper(useWrapping = false) 어노테이션을 추가하여 XML 배열 수신 시 별도의 래퍼 엘리먼트 없이도 데이터를 올바르게 파싱하도록 설정했습니다.

**동적으로 바뀔 변경사항**

* 입력되는 XML 데이터 내 배열 요소들이 별도의 감싸는(wrapper) 태그 없이 나열되는 구조일 때, 해당 데이터가 row 리스트 필드에 바인딩되는 방식이 동적으로 결정됩니다.

## 주요 효과

* XML 데이터 파싱 시 발생할 수 있는 역직렬화 오류를 방지하고 데이터 정합성을 확보했습니다.
* 외부 API(서울시 문화행사 정보 등)의 XML 응답 구조와 자바 객체 모델 간의 규격을 일치시켜 통신 안정성을 높였습니다.
* Jackson 라이브러리의 XML 처리 동작을 명시적으로 제어하여 의도치 않은 매핑 예외를 차단했습니다.