### PR TITLE
Fix repository mock method call consistency in MeetingServiceTest

### DIFF
--- a/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/eventitta/meeting/service/MeetingServiceTest.java
@@ -164,7 +164,7 @@ class MeetingServiceTest {
             .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByMeetingIdAndUser_Id(meetingId, userId))
             .willReturn(Optional.empty());
         MeetingParticipant saved = MeetingParticipant.builder()
@@ -290,7 +290,7 @@ class MeetingServiceTest {
             .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByMeetingIdAndUser_Id(meetingId, userId))
             .willReturn(Optional.of(participant));
 
@@ -491,7 +491,7 @@ class MeetingServiceTest {
         meeting.delete();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
 
         // when & then
         assertThatThrownBy(() -> meetingService.joinMeeting(userId, meetingId))
@@ -560,7 +560,7 @@ class MeetingServiceTest {
             .build();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(meetingRepository.findById(meetingId)).willReturn(Optional.of(meeting));
+        given(meetingRepository.findByIdForUpdate(meetingId)).willReturn(Optional.of(meeting));
         given(participantRepository.findByMeetingIdAndUser_Id(meetingId, userId))
             .willReturn(Optional.of(participant));
 


### PR DESCRIPTION
## 요약

`MeetingServiceTest` 클래스 내에서 `meetingRepository`를 모킹하는 방식을 각 테스트 시나리오의 의도에 맞게 수정했습니다. 비관적 락(Pessimistic Lock)이 필요한 경우와 그렇지 않은 경우를 구분하여 실제 서비스 로직과 테스트 코드 간의 정합성을 맞췄습니다.

## 주요 변경사항

* 불필요한 락 모킹 제거: 별도의 데이터 잠금이 필요 없는 `joinMeeting_returnsPendingParticipant`, `joinMeeting_onDeletedMeeting_throwsException` 테스트에서 기존 `findByIdForUpdate` 모킹을 `findById`로 변경했습니다.
* 적절한 락 모킹 적용: 참여 인원 감소 등 동시성 제어가 필요한 `cancelJoin_approvedParticipant_decrementsCount`, `cancelJoin_rejectedParticipant_throwsException` 테스트에서 기존 `findById` 모킹을 `findByIdForUpdate`로 변경했습니다.

**동적으로 바뀔 변경사항**

* 각 테스트 시나리오가 실행될 때, 서비스 로직 내부에서 호출하는 리포지토리 메서드와 테스트 코드에서 설정한 모킹 메서드가 정확히 일치하게 되어 테스트 통과 여부가 결정됩니다.
* 락 사용 여부에 따라 테스트 환경에서의 데이터 조회 및 수정 흐름이 실제 운영 환경의 비관적 락 메커니즘과 동일하게 시뮬레이션됩니다.

## 주요 효과

* 테스트 코드와 실제 비즈니스 로직 간의 불일치를 해결하여 단위 테스트의 신뢰성을 확보했습니다.
* 비관적 락이 필요한 로직에 대해 적절한 메서드가 호출되는지 테스트 단계에서 검증할 수 있게 되었습니다.
* 각 테스트의 의도를 명확히 하여 추후 로직 수정 시 발생할 수 있는 부수 효과를 방지하고 유지보수성을 높였습니다.