### PR TITLE
refactor(auth): introduce service dto layer for auth flow

### DIFF
--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -1,9 +1,11 @@
 package com.eventitta.auth.controller;
 
+import com.eventitta.auth.controller.request.SignInRequest;
 import com.eventitta.auth.controller.request.SignUpRequest;
 import com.eventitta.auth.controller.response.SignUpResponse;
-import com.eventitta.auth.dto.request.SignInRequest;
 import com.eventitta.auth.service.AuthService;
+import com.eventitta.auth.service.dto.LogoutCommand;
+import com.eventitta.auth.service.dto.RefreshCommand;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -39,7 +41,7 @@ public class AuthController {
     })
     @PostMapping("/login")
     public ResponseEntity<Void> login(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
-        authService.login(request, response);
+        authService.login(request.toCommand(), response);
         return ResponseEntity.ok().build();
     }
 
@@ -53,7 +55,7 @@ public class AuthController {
         @CookieValue(name = REFRESH_TOKEN, required = false) String refreshToken,
         HttpServletResponse response
     ) {
-        authService.refresh(accessToken, refreshToken, response);
+        authService.refresh(new RefreshCommand(accessToken, refreshToken), response);
         return ResponseEntity.ok().build();
     }
 
@@ -69,7 +71,7 @@ public class AuthController {
         @CookieValue(name = REFRESH_TOKEN, required = false) String refreshToken,
         HttpServletResponse response
     ) {
-        authService.logout(accessToken, response);
+        authService.logout(new LogoutCommand(accessToken), response);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/eventitta/auth/controller/request/SignInRequest.java
+++ b/src/main/java/com/eventitta/auth/controller/request/SignInRequest.java
@@ -1,5 +1,6 @@
-package com.eventitta.auth.dto.request;
+package com.eventitta.auth.controller.request;
 
+import com.eventitta.auth.service.dto.SignInCommand;
 import com.eventitta.common.constants.RegexPattern;
 import com.eventitta.common.constants.ValidationMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,4 +18,7 @@ public record SignInRequest(
     @Pattern(regexp = RegexPattern.PASSWORD, message = ValidationMessage.PASSWORD)
     String password
 ) {
+    public SignInCommand toCommand() {
+        return new SignInCommand(email, password);
+    }
 }

--- a/src/main/java/com/eventitta/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/eventitta/auth/dto/response/TokenResponse.java
@@ -1,4 +1,0 @@
-package com.eventitta.auth.dto.response;
-
-public record TokenResponse(String accessToken, String refreshToken) {
-}

--- a/src/main/java/com/eventitta/auth/service/AuthService.java
+++ b/src/main/java/com/eventitta/auth/service/AuthService.java
@@ -1,11 +1,13 @@
 package com.eventitta.auth.service;
 
-import com.eventitta.auth.dto.request.SignInRequest;
-import com.eventitta.auth.dto.response.TokenResponse;
 import com.eventitta.auth.exception.AuthException;
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.service.dto.LogoutCommand;
+import com.eventitta.auth.service.dto.RefreshCommand;
+import com.eventitta.auth.service.dto.SignInCommand;
 import com.eventitta.auth.service.dto.SignUpCommand;
 import com.eventitta.auth.service.dto.SignUpResult;
+import com.eventitta.auth.service.dto.TokenResult;
 import com.eventitta.common.util.CookieUtil;
 import com.eventitta.user.domain.User;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,36 +42,36 @@ public class AuthService {
         return SignUpResult.of(user);
     }
 
-    public void login(SignInRequest request, HttpServletResponse response) {
-        log.info("[로그인 시도] email={}", request.email());
+    public void login(SignInCommand command, HttpServletResponse response) {
+        log.info("[로그인 시도] email={}", command.email());
 
         try {
-            Long userId = loginService.authenticate(request.email(), request.password());
-            TokenResponse tokens = tokenService.issueTokens(userId);
+            Long userId = loginService.authenticate(command.email(), command.password());
+            TokenResult tokens = tokenService.issueTokens(userId);
             CookieUtil.addTokenCookies(response, tokens, jwtTokenProvider);
 
-            log.info("[로그인 성공] userId={}, email={}", userId, request.email());
+            log.info("[로그인 성공] userId={}, email={}", userId, command.email());
         } catch (AuthenticationException e) {
-            log.warn("[로그인 실패] email={}, reason={}", request.email(), "잘못된 인증 정보");
+            log.warn("[로그인 실패] email={}, reason={}", command.email(), "잘못된 인증 정보");
             throw INVALID_CREDENTIALS.defaultException(e);
         }
     }
 
-    public void refresh(String accessToken, String refreshToken, HttpServletResponse resp) {
+    public void refresh(RefreshCommand command, HttpServletResponse resp) {
         log.info("[토큰 갱신 시작]");
 
-        TokenResponse tokens = refreshService.refresh(accessToken, refreshToken);
+        TokenResult tokens = refreshService.refresh(command);
         CookieUtil.addTokenCookies(resp, tokens, jwtTokenProvider);
 
         log.info("[토큰 갱신 완료]");
     }
 
-    public void logout(String accessToken, HttpServletResponse response) {
+    public void logout(LogoutCommand command, HttpServletResponse response) {
         log.info("[로그아웃 시작]");
 
-        if (StringUtils.hasText(accessToken)) {
+        if (StringUtils.hasText(command.accessToken())) {
             try {
-                refreshService.invalidateByAccessToken(accessToken);
+                refreshService.invalidateByAccessToken(command.accessToken());
             } catch (AuthException e) {
                 log.debug("[로그아웃] 토큰 검증 오류 무시", e);
             }

--- a/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
@@ -1,9 +1,10 @@
 package com.eventitta.auth.service;
 
 import com.eventitta.auth.domain.RefreshToken;
-import com.eventitta.auth.dto.response.TokenResponse;
 import com.eventitta.auth.jwt.JwtTokenProvider;
 import com.eventitta.auth.repository.RefreshTokenRepository;
+import com.eventitta.auth.service.dto.RefreshCommand;
+import com.eventitta.auth.service.dto.TokenResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,19 +23,19 @@ public class RefreshTokenService {
     private final Pbkdf2PasswordEncoder rtEncoder;
     private final TokenService tokenService;
 
-    public TokenResponse refresh(String accessToken, String refreshToken) {
-        if (accessToken == null || accessToken.isBlank()) {
+    public TokenResult refresh(RefreshCommand command) {
+        if (command.accessToken() == null || command.accessToken().isBlank()) {
             throw ACCESS_TOKEN_INVALID.defaultException();
         }
-        if (refreshToken == null || refreshToken.isBlank()) {
+        if (command.refreshToken() == null || command.refreshToken().isBlank()) {
             throw REFRESH_TOKEN_MISSING.defaultException();
         }
 
-        Long userId = tokenProvider.getUserIdFromExpiredToken(accessToken);
+        Long userId = tokenProvider.getUserIdFromExpiredToken(command.accessToken());
 
         RefreshToken entity = rtRepo.findAllByUserId(userId)
             .stream()
-            .filter(token -> rtEncoder.matches(refreshToken, token.getTokenHash()))
+            .filter(token -> rtEncoder.matches(command.refreshToken(), token.getTokenHash()))
             .findFirst()
             .orElseThrow(REFRESH_TOKEN_INVALID::defaultException);
 

--- a/src/main/java/com/eventitta/auth/service/TokenService.java
+++ b/src/main/java/com/eventitta/auth/service/TokenService.java
@@ -1,9 +1,9 @@
 package com.eventitta.auth.service;
 
 import com.eventitta.auth.domain.RefreshToken;
-import com.eventitta.auth.dto.response.TokenResponse;
 import com.eventitta.auth.jwt.JwtTokenProvider;
 import com.eventitta.auth.repository.RefreshTokenRepository;
+import com.eventitta.auth.service.dto.TokenResult;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +24,14 @@ public class TokenService {
     private final Pbkdf2PasswordEncoder pbkdf2PasswordEncoder;
     private final UserRepository userRepository;
 
-    public TokenResponse issueTokens(Long userId) {
+    public TokenResult issueTokens(Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(NOT_FOUND_USER_ID::defaultException);
 
         String at = tokenProvider.createAccessToken(userId, user.getEmail(), user.getRole().name());
         String rt = tokenProvider.createRefreshToken();
         persistRefreshToken(userId, rt);
-        return new TokenResponse(at, rt);
+        return new TokenResult(at, rt);
     }
 
     private void persistRefreshToken(Long userId, String rawRt) {

--- a/src/main/java/com/eventitta/auth/service/dto/LogoutCommand.java
+++ b/src/main/java/com/eventitta/auth/service/dto/LogoutCommand.java
@@ -1,0 +1,6 @@
+package com.eventitta.auth.service.dto;
+
+public record LogoutCommand(
+    String accessToken
+) {
+}

--- a/src/main/java/com/eventitta/auth/service/dto/RefreshCommand.java
+++ b/src/main/java/com/eventitta/auth/service/dto/RefreshCommand.java
@@ -1,0 +1,7 @@
+package com.eventitta.auth.service.dto;
+
+public record RefreshCommand(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/com/eventitta/auth/service/dto/SignInCommand.java
+++ b/src/main/java/com/eventitta/auth/service/dto/SignInCommand.java
@@ -1,0 +1,7 @@
+package com.eventitta.auth.service.dto;
+
+public record SignInCommand(
+    String email,
+    String password
+) {
+}

--- a/src/main/java/com/eventitta/auth/service/dto/TokenResult.java
+++ b/src/main/java/com/eventitta/auth/service/dto/TokenResult.java
@@ -1,0 +1,7 @@
+package com.eventitta.auth.service.dto;
+
+public record TokenResult(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/com/eventitta/common/util/CookieUtil.java
+++ b/src/main/java/com/eventitta/common/util/CookieUtil.java
@@ -1,7 +1,7 @@
 package com.eventitta.common.util;
 
-import com.eventitta.auth.dto.response.TokenResponse;
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.service.dto.TokenResult;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -40,7 +40,7 @@ public final class CookieUtil {
 
     public static void addTokenCookies(
         HttpServletResponse resp,
-        TokenResponse tokens,
+        TokenResult tokens,
         JwtTokenProvider prov) {
 
         resp.addHeader(

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -1,9 +1,12 @@
 package com.eventitta.auth.controller;
 
+import com.eventitta.auth.controller.request.SignInRequest;
 import com.eventitta.auth.controller.request.SignUpRequest;
-import com.eventitta.auth.dto.request.SignInRequest;
 import com.eventitta.auth.jwt.service.UserInfoService;
 import com.eventitta.auth.service.AuthService;
+import com.eventitta.auth.service.dto.LogoutCommand;
+import com.eventitta.auth.service.dto.RefreshCommand;
+import com.eventitta.auth.service.dto.SignInCommand;
 import com.eventitta.auth.service.dto.SignUpCommand;
 import com.eventitta.auth.service.dto.SignUpResult;
 import com.eventitta.notification.resolver.AlertLevelResolver;
@@ -213,7 +216,7 @@ class AuthControllerTest {
 
             // then
             result.andExpect(status().isOk());
-            then(authService).should().login(any(SignInRequest.class), any(HttpServletResponse.class));
+            then(authService).should().login(any(SignInCommand.class), any(HttpServletResponse.class));
         }
 
         @Test
@@ -304,7 +307,7 @@ class AuthControllerTest {
 
             willThrow(INVALID_CREDENTIALS.defaultException())
                 .given(authService)
-                .login(any(SignInRequest.class), any(HttpServletResponse.class));
+                .login(any(SignInCommand.class), any(HttpServletResponse.class));
 
             // when & then
             mockMvc.perform(
@@ -335,7 +338,7 @@ class AuthControllerTest {
 
             // when & then
             then(authService).should()
-                .refresh(eq("expired-access-token"), eq("valid-refresh-token"), any(HttpServletResponse.class));
+                .refresh(eq(new RefreshCommand("expired-access-token", "valid-refresh-token")), any(HttpServletResponse.class));
         }
 
         @Test
@@ -344,7 +347,7 @@ class AuthControllerTest {
             // given
             willThrow(REFRESH_TOKEN_MISSING.defaultException())
                 .given(authService)
-                .refresh(any(), any(), any(HttpServletResponse.class));
+                .refresh(any(RefreshCommand.class), any(HttpServletResponse.class));
 
             // when & then
             mockMvc.perform(
@@ -361,7 +364,7 @@ class AuthControllerTest {
             // given
             willThrow(REFRESH_TOKEN_INVALID.defaultException())
                 .given(authService)
-                .refresh(any(), any(), any(HttpServletResponse.class));
+                .refresh(any(RefreshCommand.class), any(HttpServletResponse.class));
 
             // when & then
             mockMvc.perform(
@@ -391,7 +394,7 @@ class AuthControllerTest {
 
             // then
             then(authService).should()
-                .logout(eq("valid-access-token"), any(HttpServletResponse.class));
+                .logout(eq(new LogoutCommand("valid-access-token")), any(HttpServletResponse.class));
         }
 
         @Test
@@ -403,7 +406,7 @@ class AuthControllerTest {
 
             // then
             then(authService).should()
-                .logout(isNull(), any(HttpServletResponse.class));
+                .logout(eq(new LogoutCommand(null)), any(HttpServletResponse.class));
         }
     }
 }

--- a/src/test/java/com/eventitta/common/util/CookieUtilTest.java
+++ b/src/test/java/com/eventitta/common/util/CookieUtilTest.java
@@ -43,7 +43,7 @@ class CookieUtilTest {
 
     @Test
     @DisplayName("응답 헤더에 두 개의 엑세스/리프레시 토큰 쿠키를 추가한다")
-    void givenTokenResponse_whenAddTokenCookies_thenTwoSetCookieHeadersAreAppended() {
+    void givenTokenResult_whenAddTokenCookies_thenTwoSetCookieHeadersAreAppended() {
         // given
         TokenResult tokens = new TokenResult("at-xyz", "rt-abc");
         JwtTokenProvider mockProvider = org.mockito.Mockito.mock(JwtTokenProvider.class);

--- a/src/test/java/com/eventitta/common/util/CookieUtilTest.java
+++ b/src/test/java/com/eventitta/common/util/CookieUtilTest.java
@@ -1,7 +1,7 @@
 package com.eventitta.common.util;
 
-import com.eventitta.auth.dto.response.TokenResponse;
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.service.dto.TokenResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +45,7 @@ class CookieUtilTest {
     @DisplayName("응답 헤더에 두 개의 엑세스/리프레시 토큰 쿠키를 추가한다")
     void givenTokenResponse_whenAddTokenCookies_thenTwoSetCookieHeadersAreAppended() {
         // given
-        TokenResponse tokens = new TokenResponse("at-xyz", "rt-abc");
+        TokenResult tokens = new TokenResult("at-xyz", "rt-abc");
         JwtTokenProvider mockProvider = org.mockito.Mockito.mock(JwtTokenProvider.class);
         given(mockProvider.getAccessTokenValidityMs()).willReturn(1_000L);
         given(mockProvider.getRefreshTokenValidityMs()).willReturn(2_000L);


### PR DESCRIPTION

## 요약

인증 프로세스 전반에 Command 및 Result DTO를 도입하여 계층 간 책임을 분리하고, 코드의 명확성과 유지보수성을 강화함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* 서비스 계층에서 기존 Request/Response DTO 및 원시 타입(String 등)을 대신할 `SignInCommand`, `RefreshCommand`, `LogoutCommand`, `TokenResult` 도입
* `AuthService`, `RefreshTokenService`, `TokenService`, `CookieUtil`의 메서드 시그니처를 Command 입력 및 Result 반환 구조로 변경
* `AuthController`에서 외부 요청 객체를 Command로 변환하여 서비스를 호출하도록 로직 수정 및 엔드포인트 최적화
* `SignInRequest`를 `controller/request` 패키지로 이동하여 패키지 구조 표준화 및 불필요해진 `TokenResponse` 제거
* 변경된 DTO 구조 및 메서드 시그니처에 맞춰 `AuthControllerTest`, `CookieUtilTest` 등 테스트 코드 전면 업데이트

## 주요 효과

* 서비스 계층이 외부 API 스펙(Request/Response)에 직접 의존하지 않도록 하여 계층 간 결합도를 낮춤
* Command/Result 패턴을 통해 데이터의 흐름과 각 객체의 역할을 직관적으로 파악 가능
* 테스트 코드의 일관성을 확보하고, 향후 인증 로직 확장 시 발생할 수 있는 사이드 이펙트를 최소화함