### PR TITLE
Remove unused imports from AuthService

### DIFF
--- a/src/main/java/com/eventitta/auth/service/AuthService.java
+++ b/src/main/java/com/eventitta/auth/service/AuthService.java
@@ -2,25 +2,18 @@ package com.eventitta.auth.service;
 
 import com.eventitta.auth.exception.AuthException;
 import com.eventitta.auth.jwt.JwtTokenProvider;
-import com.eventitta.auth.service.dto.LogoutCommand;
-import com.eventitta.auth.service.dto.RefreshCommand;
-import com.eventitta.auth.service.dto.SignInCommand;
-import com.eventitta.auth.service.dto.SignUpCommand;
-import com.eventitta.auth.service.dto.SignUpResult;
-import com.eventitta.auth.service.dto.TokenResult;
+import com.eventitta.auth.service.dto.*;
 import com.eventitta.common.util.CookieUtil;
 import com.eventitta.user.domain.User;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
 import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
-import static com.eventitta.auth.exception.AuthErrorCode.INVALID_CREDENTIALS;
 
 @Slf4j
 @Service


### PR DESCRIPTION


## 요약

AuthService.java 내 DTO 임포트 구문을 와일드카드 방식으로 통합하여 코드를 간소화함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `AuthService.java` 파일에서 `com.eventitta.auth.service.dto` 패키지의 개별 DTO 임포트 선언들을 와일드카드(`*`)를 사용하는 단일 임포트 구문으로 교체함.

## 주요 효과

* 반복되는 임포트 구문을 줄여 코드 상단의 가독성을 개선하고 전반적인 코드 구성을 깔끔하게 유지함.
* 향후 동일 패키지 내의 새로운 DTO를 추가하여 사용할 때 별도의 임포트 수정 없이 즉시 참조가 가능하여 개발 편의성을 높임.