### PR TITLE
test(auth): add SignUpService unit tests

### DIFF
--- a/src/test/java/com/eventitta/auth/service/SignUpServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/SignUpServiceTest.java
@@ -1,0 +1,111 @@
+package com.eventitta.auth.service;
+
+import com.eventitta.auth.exception.AuthException;
+import com.eventitta.auth.service.dto.SignUpCommand;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static com.eventitta.auth.exception.AuthErrorCode.CONFLICTED_EMAIL;
+import static com.eventitta.auth.exception.AuthErrorCode.CONFLICTED_NICKNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SignUpServiceTest {
+
+    @InjectMocks
+    private SignUpService signUpService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("중복되지 않은 이메일과 닉네임이면 비밀번호를 인코딩해 사용자를 저장한다.")
+    void register_success() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+            "test@example.com",
+            "rawPassword",
+            "tester"
+        );
+
+        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByNickname(command.nickname())).thenReturn(false);
+        when(passwordEncoder.encode(command.password())).thenReturn("encoded-password");
+
+        User savedUser = mock(User.class);
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // when
+        User result = signUpService.register(command);
+
+        // then
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User user = userCaptor.getValue();
+        assertThat(user.getEmail()).isEqualTo(command.email());
+        assertThat(user.getNickname()).isEqualTo(command.nickname());
+        assertThat(user.getPassword()).isEqualTo("encoded-password");
+        assertThat(result).isEqualTo(savedUser);
+    }
+
+    @Test
+    @DisplayName("이메일이 이미 존재하면 중복된 이메일이라는 예외를 던진다.")
+    void register_fail_when_email_conflicted() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+            "test@example.com",
+            "rawPassword",
+            "tester"
+        );
+
+        when(userRepository.existsByEmail(command.email())).thenReturn(true);
+
+        // when
+        Throwable thrown = catchThrowable(() -> signUpService.register(command));
+
+        // then
+        assertThat(thrown).isInstanceOf(AuthException.class);
+        assertThat(((AuthException) thrown).getErrorCode()).isEqualTo(CONFLICTED_EMAIL);
+
+        verify(userRepository, never()).existsByNickname(anyString());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일은 중복되지 않았지만 닉네임이 이미 존재하면 중복된 닉네임이라는 예외를 던진다.")
+    void register_fail_when_nickname_conflicted() {
+        // given
+        SignUpCommand command = new SignUpCommand(
+            "test@example.com",
+            "rawPassword",
+            "tester"
+        );
+
+        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByNickname(command.nickname())).thenReturn(true);
+
+        // when
+        Throwable thrown = catchThrowable(() -> signUpService.register(command));
+
+        // then
+        assertThat(thrown).isInstanceOf(AuthException.class);
+        assertThat(((AuthException) thrown).getErrorCode()).isEqualTo(CONFLICTED_NICKNAME);
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+}


### PR DESCRIPTION


## 요약

`SignUpService`의 회원가입 로직에 대한 단위 테스트를 추가하여, 정상적인 가입 절차와 예외 상황(중복 등)에서의 동작을 검증함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `SignUpServiceTest` 클래스를 신규 생성하여 `register` 메서드에 대한 포괄적인 테스트 시나리오 작성
* 성공적인 회원가입 시 비밀번호 암호화(Encoding) 및 데이터 저장(Persistence)이 올바르게 수행되는지 검증
* 이미 존재하는 이메일 또는 닉네임으로 가입 시도 시, 적절한 예외가 발생하는지 확인하는 테스트 추가
* 중복 예외 발생 시 리포지토리의 저장 로직이 호출되지 않도록 보장하는 검증 로직(Verify) 포함

## 주요 효과

* 회원가입 핵심 로직의 안정성을 확보하고, 중복 가입과 같은 비즈니스 예외 상황에 대한 대응력을 높임
* 비밀번호 암호화와 같은 보안 관련 로직이 의도대로 동작함을 보장함
* 코드 수정 시 기존 회원가입 기능의 영향도를 즉각적으로 파악할 수 있는 안전장치 마련
