### PR TITLE
Test/rebuild token service test

### DIFF
--- a/src/main/java/com/eventitta/auth/service/TokenService.java
+++ b/src/main/java/com/eventitta/auth/service/TokenService.java
@@ -30,15 +30,14 @@ public class TokenService {
 
         String at = tokenProvider.createAccessToken(userId, user.getEmail(), user.getRole().name());
         String rt = tokenProvider.createRefreshToken();
-        persistRefreshToken(userId, rt);
+        persistRefreshToken(user, rt);
         return new TokenResult(at, rt);
     }
 
-    private void persistRefreshToken(Long userId, String rawRt) {
+    private void persistRefreshToken(User user, String rawRt) {
         String hash = pbkdf2PasswordEncoder.encode(rawRt);
         Instant expiresAt = tokenProvider.getRefreshTokenExpiry();
 
-        User u = userRepository.getReferenceById(userId);
-        refreshTokenRepository.save(new RefreshToken(u, hash, expiresAt));
+        refreshTokenRepository.save(new RefreshToken(user, hash, expiresAt));
     }
 }

--- a/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,154 @@
+package com.eventitta.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.eventitta.auth.domain.RefreshToken;
+import com.eventitta.auth.exception.AuthException;
+import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.repository.RefreshTokenRepository;
+import com.eventitta.auth.service.dto.RefreshCommand;
+import com.eventitta.auth.service.dto.TokenResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private JwtTokenProvider tokenProvider;
+    @Mock
+    private RefreshTokenRepository rtRepo;
+    @Mock
+    private Pbkdf2PasswordEncoder rtEncoder;
+    @Mock
+    private TokenService tokenService;
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class Refresh {
+
+        @Test
+        @DisplayName("액세스 토큰이 비어 있으면 토큰을 재발급할 수 없다.")
+        void refresh_whenAccessTokenIsBlank_thenThrowsException() {
+            // given
+            RefreshCommand command = new RefreshCommand(" ", "refresh-token");
+
+            // when // then
+            assertThatThrownBy(() -> refreshTokenService.refresh(command))
+                .isInstanceOf(AuthException.class);
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰이 비어 있으면 토큰을 재발급할 수 없다.")
+        void refresh_whenRefreshTokenIsBlank_thenThrowsException() {
+            // given
+            RefreshCommand command = new RefreshCommand("expired-access-token", " ");
+
+            // when // then
+            assertThatThrownBy(() -> refreshTokenService.refresh(command))
+                .isInstanceOf(AuthException.class);
+        }
+
+        @Test
+        @DisplayName("저장된 리프레시 토큰과 일치하지 않으면 토큰을 재발급할 수 없다.")
+        void refresh_whenRefreshTokenDoesNotMatch_thenThrowsException() {
+            // given
+            Long userId = 1L;
+            RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
+            RefreshToken tokenEntity = mock(RefreshToken.class);
+
+            given(tokenProvider.getUserIdFromExpiredToken(command.accessToken())).willReturn(userId);
+            given(rtRepo.findAllByUserId(userId)).willReturn(List.of(tokenEntity));
+            given(tokenEntity.getTokenHash()).willReturn("stored-hash");
+            given(rtEncoder.matches(command.refreshToken(), "stored-hash")).willReturn(false);
+
+            // when // then
+            assertThatThrownBy(() -> refreshTokenService.refresh(command))
+                .isInstanceOf(AuthException.class);
+
+            then(rtRepo).should(never()).delete(tokenEntity);
+            then(tokenService).should(never()).issueTokens(anyLong());
+        }
+
+        @Test
+        @DisplayName("만료된 리프레시 토큰이면 토큰을 재발급할 수 없다.")
+        void refresh_whenRefreshTokenIsExpired_thenThrowsException() {
+            // given
+            Long userId = 1L;
+            RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
+            RefreshToken tokenEntity = mock(RefreshToken.class);
+
+            given(tokenProvider.getUserIdFromExpiredToken(command.accessToken())).willReturn(userId);
+            given(rtRepo.findAllByUserId(userId)).willReturn(List.of(tokenEntity));
+            given(tokenEntity.getTokenHash()).willReturn("stored-hash");
+            given(rtEncoder.matches(command.refreshToken(), "stored-hash")).willReturn(true);
+            given(tokenEntity.getExpiresAt()).willReturn(LocalDateTime.now().minusMinutes(1));
+
+            // when // then
+            assertThatThrownBy(() -> refreshTokenService.refresh(command))
+                .isInstanceOf(AuthException.class);
+
+            then(rtRepo).should(never()).delete(tokenEntity);
+            then(tokenService).should(never()).issueTokens(anyLong());
+        }
+
+        @Test
+        @DisplayName("유효한 리프레시 토큰이면 기존 리프레시 토큰을 삭제하고 토큰을 재발급한다.")
+        void refresh_whenRefreshTokenMatchesAndIsNotExpired_thenReissuesTokens() {
+            // given
+            Long userId = 1L;
+            RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
+            RefreshToken tokenEntity = mock(RefreshToken.class);
+            TokenResult reissuedTokens = new TokenResult("new-access-token", "new-refresh-token");
+
+            given(tokenProvider.getUserIdFromExpiredToken(command.accessToken())).willReturn(userId);
+            given(rtRepo.findAllByUserId(userId)).willReturn(List.of(tokenEntity));
+            given(tokenEntity.getTokenHash()).willReturn("stored-hash");
+            given(rtEncoder.matches(command.refreshToken(), "stored-hash")).willReturn(true);
+            given(tokenEntity.getExpiresAt()).willReturn(LocalDateTime.now().plusMinutes(30));
+            given(tokenService.issueTokens(userId)).willReturn(reissuedTokens);
+
+            // when
+            TokenResult result = refreshTokenService.refresh(command);
+
+            // then
+            assertThat(result).isEqualTo(reissuedTokens);
+            then(rtRepo).should().delete(tokenEntity);
+            then(tokenService).should().issueTokens(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("리프레시 토큰 무효화")
+    class InvalidateByAccessToken {
+
+        @Test
+        @DisplayName("액세스 토큰에서 회원 식별자를 추출해 해당 회원의 리프레시 토큰을 모두 삭제한다.")
+        void invalidateByAccessToken_whenAccessTokenIsProvided_thenDeletesAllRefreshTokensOfUser() {
+            // given
+            String accessToken = "expired-access-token";
+            Long userId = 1L;
+            given(tokenProvider.getUserIdFromExpiredToken(accessToken)).willReturn(userId);
+
+            // when
+            refreshTokenService.invalidateByAccessToken(accessToken);
+
+            // then
+            then(rtRepo).should().deleteByUserId(userId);
+        }
+    }
+}

--- a/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
@@ -1,0 +1,108 @@
+package com.eventitta.auth.service;
+
+import com.eventitta.auth.domain.RefreshToken;
+import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.repository.RefreshTokenRepository;
+import com.eventitta.auth.service.dto.TokenResult;
+import com.eventitta.user.domain.User;
+import com.eventitta.user.exception.UserException;
+import com.eventitta.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import static com.eventitta.user.domain.Role.USER;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Mock
+    private JwtTokenProvider tokenProvider;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private Pbkdf2PasswordEncoder pbkdf2PasswordEncoder;
+    @Mock
+    private UserRepository userRepository;
+
+    @Captor
+    private ArgumentCaptor<RefreshToken> refreshTokenCaptor;
+
+    @Nested
+    @DisplayName("토큰 발급")
+    class IssueTokens {
+
+        @Test
+        @DisplayName("존재하는 회원이면 액세스 토큰과 리프레시 토큰을 발급하고 리프레시 토큰을 저장한다.")
+        void issueTokens_whenUserExists_thenReturnsTokensAndStoresRefreshToken() {
+            // given
+            Long userId = 1L;
+            User user = createUser(userId, "spring@test.com");
+
+            given(userRepository.findById(userId)).willReturn(of(user));
+            given(tokenProvider.createAccessToken(userId, user.getEmail(), user.getRole().name()))
+                .willReturn("access-token");
+            given(tokenProvider.createRefreshToken()).willReturn("raw-refresh-token");
+            given(pbkdf2PasswordEncoder.encode("raw-refresh-token")).willReturn("encoded-refresh-token");
+            given(tokenProvider.getRefreshTokenExpiry()).willReturn(Instant.parse("2026-03-11T14:59:00Z"));
+            // when
+            TokenResult result = tokenService.issueTokens(userId);
+
+            // then
+            assertThat(result.accessToken()).isEqualTo("access-token");
+            assertThat(result.refreshToken()).isEqualTo("raw-refresh-token");
+
+            then(refreshTokenRepository).should().save(refreshTokenCaptor.capture());
+
+            RefreshToken savedToken = refreshTokenCaptor.getValue();
+            assertThat(savedToken.getTokenHash()).isEqualTo("encoded-refresh-token");
+            assertThat(savedToken.getExpiresAt()).isEqualTo(LocalDateTime.of(2026, 3, 11, 23, 59));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원이면 토큰을 발급할 수 없다.")
+        void issueTokens_whenUserDoesNotExist_thenThrowsException() {
+            // given
+            Long userId = 999L;
+            given(userRepository.findById(userId)).willReturn(empty());
+
+            // when // then
+            assertThatThrownBy(() -> tokenService.issueTokens(userId))
+                .isInstanceOf(UserException.class);
+
+            then(refreshTokenRepository).should(never()).save(any());
+        }
+    }
+
+    private User createUser(Long id, String email) {
+        User user = User.builder()
+            .email(email)
+            .password("encoded-password")
+            .nickname("spring")
+            .role(USER)
+            .build();
+
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import static com.eventitta.user.domain.Role.USER;
 import static java.util.Optional.empty;
@@ -64,7 +65,10 @@ class TokenServiceTest {
                 .willReturn("access-token");
             given(tokenProvider.createRefreshToken()).willReturn("raw-refresh-token");
             given(pbkdf2PasswordEncoder.encode("raw-refresh-token")).willReturn("encoded-refresh-token");
-            given(tokenProvider.getRefreshTokenExpiry()).willReturn(Instant.parse("2026-03-11T14:59:00Z"));
+
+            Instant expectedExpiry = Instant.parse("2026-03-11T14:59:00Z");
+            given(tokenProvider.getRefreshTokenExpiry()).willReturn(expectedExpiry);
+
             // when
             TokenResult result = tokenService.issueTokens(userId);
 
@@ -76,7 +80,8 @@ class TokenServiceTest {
 
             RefreshToken savedToken = refreshTokenCaptor.getValue();
             assertThat(savedToken.getTokenHash()).isEqualTo("encoded-refresh-token");
-            assertThat(savedToken.getExpiresAt()).isEqualTo(LocalDateTime.of(2026, 3, 11, 23, 59));
+            assertThat(savedToken.getExpiresAt())
+                .isEqualTo(LocalDateTime.ofInstant(expectedExpiry, ZoneId.systemDefault()));
         }
 
         @Test


### PR DESCRIPTION

## 요약

토큰 발행 및 갱신 로직에 대한 종합적인 단위 테스트를 추가하고, `TokenService`의 리프레시 토큰 저장 로직을 엔티티 중심으로 리팩토링함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `TokenServiceTest` 클래스를 추가하여 토큰 발행, 저장 및 사용자 미존재 시의 예외 처리 로직 검증
* `RefreshTokenServiceTest` 클래스를 추가하여 토큰 재발급, 빈 토큰/불일치/만료/액세스 토큰 기반 무효화 시나리오 테스트
* `TokenService` 내 `persistRefreshToken` 메서드가 `userId` 대신 `User` 객체를 직접 전달받도록 리팩토링
* 리프레시 토큰 저장 및 관련 리포지토리 호출 시 `User` 객체를 직접 사용하도록 수정하여 불필요한 데이터베이스 조회 제거

## 주요 효과

* 토큰 만료 및 사용자 검증 등 보안에 민감한 엣지 케이스를 테스트로 보호하여 시스템 안정성 강화
* 엔티티를 직접 전달하는 방식으로 리팩토링하여 비즈니스 로직을 단순화하고 성능(DB 조회 비용) 최적화
* 리포지토리와 서비스 간의 일관된 데이터 전달 방식을 확립하여 코드의 가독성 및 유지보수성 향상

