### PR TITLE
refactor(auth): use Clock and LocalDateTime for refresh tokens

### DIFF
--- a/src/main/java/com/eventitta/auth/domain/RefreshToken.java
+++ b/src/main/java/com/eventitta/auth/domain/RefreshToken.java
@@ -8,9 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Entity
 @Getter
@@ -33,14 +31,14 @@ public class RefreshToken extends BaseTimeEntity {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
-    public RefreshToken(User user, String tokenHash, Instant expiresAt) {
+    public RefreshToken(User user, String tokenHash, LocalDateTime expiresAt) {
         this.user = user;
         this.tokenHash = tokenHash;
-        this.expiresAt = LocalDateTime.ofInstant(expiresAt, ZoneId.systemDefault());
+        this.expiresAt = expiresAt;
     }
 
-    public void updateToken(String newHash, Instant newExpiresAt) {
+    public void updateToken(String newHash, LocalDateTime newExpiresAt) {
         this.tokenHash = newHash;
-        this.expiresAt = LocalDateTime.ofInstant(newExpiresAt, ZoneId.systemDefault());
+        this.expiresAt = newExpiresAt;
     }
 }

--- a/src/main/java/com/eventitta/auth/scheduler/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/com/eventitta/auth/scheduler/RefreshTokenCleanupScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 
 @Slf4j
@@ -19,8 +20,9 @@ import java.time.LocalDateTime;
     havingValue = "true",
     matchIfMissing = true
 )
-public class RefreshTokenCleanupTask {
+public class RefreshTokenCleanupScheduler {
 
+    private final Clock clock;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
@@ -30,7 +32,7 @@ public class RefreshTokenCleanupTask {
         log.info("[Scheduler] 만료된 리프레시 토큰 정리 시작");
 
         try {
-            long deleted = refreshTokenRepository.deleteByExpiresAtBefore(LocalDateTime.now());
+            long deleted = refreshTokenRepository.deleteByExpiresAtBefore(LocalDateTime.now(clock));
             log.info("[Scheduler] 만료된 리프레시 토큰 정리 완료 - 삭제 건수: {}", deleted);
         } catch (Exception e) {
             log.error("[Scheduler] 만료된 리프레시 토큰 정리 실패", e);

--- a/src/main/java/com/eventitta/auth/service/TokenService.java
+++ b/src/main/java/com/eventitta/auth/service/TokenService.java
@@ -11,7 +11,9 @@ import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 import static com.eventitta.user.exception.UserErrorCode.NOT_FOUND_USER_ID;
 
@@ -23,6 +25,7 @@ public class TokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final Pbkdf2PasswordEncoder pbkdf2PasswordEncoder;
     private final UserRepository userRepository;
+    private final Clock clock;
 
     public TokenResult issueTokens(Long userId) {
         User user = userRepository.findById(userId)
@@ -37,7 +40,8 @@ public class TokenService {
     private void persistRefreshToken(User user, String rawRt) {
         String hash = pbkdf2PasswordEncoder.encode(rawRt);
         Instant expiresAt = tokenProvider.getRefreshTokenExpiry();
+        LocalDateTime expiresAtInAppZone = LocalDateTime.ofInstant(expiresAt, clock.getZone());
 
-        refreshTokenRepository.save(new RefreshToken(user, hash, expiresAt));
+        refreshTokenRepository.save(new RefreshToken(user, hash, expiresAtInAppZone));
     }
 }

--- a/src/main/java/com/eventitta/common/config/ClockConfig.java
+++ b/src/main/java/com/eventitta/common/config/ClockConfig.java
@@ -1,15 +1,22 @@
 package com.eventitta.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 public class ClockConfig {
+
     @Bean
-    public Clock clock() {
-        return Clock.systemDefaultZone();
+    public ZoneId applicationZoneId(@Value("${app.time-zone:Asia/Seoul}") String timeZone) {
+        return ZoneId.of(timeZone);
+    }
+
+    @Bean
+    public Clock clock(ZoneId applicationZoneId) {
+        return Clock.system(applicationZoneId);
     }
 }
-

--- a/src/main/java/com/eventitta/common/config/scheduling/SchedulingConfig.java
+++ b/src/main/java/com/eventitta/common/config/scheduling/SchedulingConfig.java
@@ -19,7 +19,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * <p>모든 스케줄러는 기본적으로 활성화되어 있으며 ({@code matchIfMissing = true}),
  * 특정 스케줄러만 비활성화하려면 해당 설정을 {@code false}로 지정하세요.
  *
- * @see com.eventitta.auth.scheduler.RefreshTokenCleanupTask
+ * @see com.eventitta.auth.scheduler.RefreshTokenCleanupScheduler
  * @see com.eventitta.festivals.scheduler.FestivalScheduler
  * @see com.eventitta.meeting.scheduler.MeetingStatusScheduler
  * @see com.eventitta.post.scheduler.PostImageFileScheduler

--- a/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -45,6 +46,8 @@ class TokenServiceTest {
     private Pbkdf2PasswordEncoder pbkdf2PasswordEncoder;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private Clock clock;
 
     @Captor
     private ArgumentCaptor<RefreshToken> refreshTokenCaptor;
@@ -67,6 +70,8 @@ class TokenServiceTest {
             given(pbkdf2PasswordEncoder.encode("raw-refresh-token")).willReturn("encoded-refresh-token");
 
             Instant expectedExpiry = Instant.parse("2026-03-11T14:59:00Z");
+            ZoneId applicationZone = ZoneId.of("Asia/Seoul");
+            given(clock.getZone()).willReturn(applicationZone);
             given(tokenProvider.getRefreshTokenExpiry()).willReturn(expectedExpiry);
 
             // when
@@ -81,7 +86,7 @@ class TokenServiceTest {
             RefreshToken savedToken = refreshTokenCaptor.getValue();
             assertThat(savedToken.getTokenHash()).isEqualTo("encoded-refresh-token");
             assertThat(savedToken.getExpiresAt())
-                .isEqualTo(LocalDateTime.ofInstant(expectedExpiry, ZoneId.systemDefault()));
+                .isEqualTo(LocalDateTime.ofInstant(expectedExpiry, applicationZone));
         }
 
         @Test

--- a/src/test/java/com/eventitta/scheduler/ShedLockIntegrationTest.java
+++ b/src/test/java/com/eventitta/scheduler/ShedLockIntegrationTest.java
@@ -2,7 +2,7 @@ package com.eventitta.scheduler;
 
 import com.eventitta.IntegrationTestSupport;
 import com.eventitta.auth.repository.RefreshTokenRepository;
-import com.eventitta.auth.scheduler.RefreshTokenCleanupTask;
+import com.eventitta.auth.scheduler.RefreshTokenCleanupScheduler;
 import com.eventitta.festivals.scheduler.FestivalScheduler;
 import com.eventitta.festivals.service.FestivalService;
 import com.eventitta.meeting.repository.MeetingRepository;
@@ -52,7 +52,7 @@ class ShedLockIntegrationTest extends IntegrationTestSupport {
     private MeetingStatusScheduler meetingStatusScheduler;
 
     @Autowired
-    private RefreshTokenCleanupTask refreshTokenCleanupTask;
+    private RefreshTokenCleanupScheduler refreshTokenCleanupScheduler;
 
     @MockitoBean
     private FestivalService festivalService;
@@ -176,7 +176,7 @@ class ShedLockIntegrationTest extends IntegrationTestSupport {
                 return 5L;
             });
 
-        runConcurrently(() -> refreshTokenCleanupTask.removeExpiredRefreshTokens());
+        runConcurrently(() -> refreshTokenCleanupScheduler.removeExpiredRefreshTokens());
 
         Thread.sleep(100); // 락 row 생성 대기
 


### PR DESCRIPTION

## 요약

인증 모듈 전반의 타임존 처리 방식을 애플리케이션 설정 기준으로 표준화하고, 리프레시 토큰 만료 로직 및 관련 스케줄러를 리팩토링함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `RefreshToken` 엔티티의 만료 시간 타입을 `Instant`에서 `LocalDateTime`으로 변경하여 명시적인 타임존 처리 지원
* `TokenService` 및 스케줄러 클래스에 `Clock` 빈을 주입하여 시스템 기본값이 아닌 설정된 타임존(Asia/Seoul 등)을 따르도록 수정
* `ClockConfig`를 도입하여 중앙 집중화된 타임존 설정 및 `Clock` 제공 로직 구축
* 기존 `RefreshTokenCleanupTask`를 `RefreshTokenCleanupScheduler`로 명칭 변경하여 구성 요소의 역할 정의 명확화
* 타임존 검증을 위해 `Clock` 모킹 로직을 포함한 단위 테스트 및 통합 테스트(ShedLock 등) 코드 업데이트

## 주요 효과

* 서버 환경(시스템 타임존)에 관계없이 일관된 토큰 만료 정책을 유지하여 타임존 불일치로 인한 인증 오류 방지
* 시간 관련 로직에 대한 테스트 용이성(Testability)을 확보하여 코드 신뢰도 향상
* 스케줄러 명칭 및 구조 정리를 통해 코드의 직관성과 유지보수성 개선

