### PR TITLE
Harden auth cookie security

### DIFF
--- a/src/main/java/com/eventitta/auth/properties/CookieProperties.java
+++ b/src/main/java/com/eventitta/auth/properties/CookieProperties.java
@@ -10,5 +10,6 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "cookie")
 public class CookieProperties {
-    private boolean secure = false;  // 기본값
+    private boolean secure = false;
+    private long accessTokenRefreshBufferMs = 300_000L;
 }

--- a/src/main/java/com/eventitta/auth/service/CookieManager.java
+++ b/src/main/java/com/eventitta/auth/service/CookieManager.java
@@ -1,6 +1,7 @@
 package com.eventitta.auth.service;
 
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.properties.CookieProperties;
 import com.eventitta.auth.service.dto.TokenResult;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
@@ -18,20 +19,22 @@ public class CookieManager {
     private static final String SAME_SITE_STRICT = "Strict";
 
     private final JwtTokenProvider tokenProvider;
+    private final CookieProperties cookieProperties;
 
-    public CookieManager(JwtTokenProvider tokenProvider) {
+    public CookieManager(JwtTokenProvider tokenProvider, CookieProperties cookieProperties) {
         this.tokenProvider = tokenProvider;
+        this.cookieProperties = cookieProperties;
     }
 
     public void addTokenCookies(HttpServletResponse resp, TokenResult tokens) {
         resp.addHeader(
             HttpHeaders.SET_COOKIE,
-            createCookie(ACCESS_TOKEN, tokens.accessToken(), tokenProvider.getAccessTokenValidityMs())
+            createAccessTokenCookie(tokens.accessToken())
                 .toString()
         );
         resp.addHeader(
             HttpHeaders.SET_COOKIE,
-            createCookie(REFRESH_TOKEN, tokens.refreshToken(), tokenProvider.getRefreshTokenValidityMs())
+            createRefreshTokenCookie(tokens.refreshToken())
                 .toString()
         );
     }
@@ -39,15 +42,27 @@ public class CookieManager {
     public void deleteCookie(HttpServletResponse resp, String name) {
         ResponseCookie c = ResponseCookie.from(name, "")
             .httpOnly(true)
+            .secure(cookieProperties.isSecure())
             .path("/")
+            .sameSite(SAME_SITE_STRICT)
             .maxAge(0)
             .build();
         resp.addHeader(HttpHeaders.SET_COOKIE, c.toString());
     }
 
+    private ResponseCookie createAccessTokenCookie(String value) {
+        long validityMs = tokenProvider.getAccessTokenValidityMs() + cookieProperties.getAccessTokenRefreshBufferMs();
+        return createCookie(ACCESS_TOKEN, value, validityMs);
+    }
+
+    private ResponseCookie createRefreshTokenCookie(String value) {
+        return createCookie(REFRESH_TOKEN, value, tokenProvider.getRefreshTokenValidityMs());
+    }
+
     private ResponseCookie createCookie(String name, String value, long validityMs) {
         return ResponseCookie.from(name, value)
             .httpOnly(true)
+            .secure(cookieProperties.isSecure())
             .path("/")
             .sameSite(SAME_SITE_STRICT)
             .maxAge(Duration.ofMillis(validityMs))

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -86,6 +86,9 @@ jwt:
   access-token-validity-ms: ${JWT_ACCESS_TOKEN_VALIDITY:3600000}
   refresh-token-validity-ms: ${JWT_REFRESH_TOKEN_VALIDITY:86400000}
 
+cookie:
+  secure: true
+
 file:
   storage:
     location: ${FILE_STORAGE_LOCATION:/app/uploads}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,7 @@ notification:
 monitoring:
   log:
     enabled: false
+
+cookie:
+  secure: false
+  access-token-refresh-buffer-ms: 300000

--- a/src/test/java/com/eventitta/auth/service/CookieManagerTest.java
+++ b/src/test/java/com/eventitta/auth/service/CookieManagerTest.java
@@ -1,0 +1,78 @@
+package com.eventitta.auth.service;
+
+import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.properties.CookieProperties;
+import com.eventitta.auth.service.dto.TokenResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CookieManagerTest {
+
+    @Mock
+    private JwtTokenProvider tokenProvider;
+
+    private CookieManager cookieManager;
+
+    @BeforeEach
+    void setUp() {
+        CookieProperties cookieProperties = new CookieProperties();
+        cookieProperties.setSecure(true);
+        cookieProperties.setAccessTokenRefreshBufferMs(300_000L);
+        cookieManager = new CookieManager(tokenProvider, cookieProperties);
+    }
+
+    @Test
+    @DisplayName("토큰 쿠키를 저장할 때 운영 보안 속성과 access token refresh 버퍼를 적용한다")
+    void addTokenCookies_appliesSecureFlagAndAccessTokenBuffer() {
+        given(tokenProvider.getAccessTokenValidityMs()).willReturn(3_600_000L);
+        given(tokenProvider.getRefreshTokenValidityMs()).willReturn(86_400_000L);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        cookieManager.addTokenCookies(response, new TokenResult("access-token", "refresh-token"));
+
+        List<String> cookies = response.getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(2);
+        assertThat(cookies).anySatisfy(cookie -> {
+            assertThat(cookie).contains("access_token=access-token");
+            assertThat(cookie).contains("Max-Age=3900");
+            assertThat(cookie).contains("Secure");
+            assertThat(cookie).contains("HttpOnly");
+            assertThat(cookie).contains("SameSite=Strict");
+        });
+        assertThat(cookies).anySatisfy(cookie -> {
+            assertThat(cookie).contains("refresh_token=refresh-token");
+            assertThat(cookie).contains("Max-Age=86400");
+            assertThat(cookie).contains("Secure");
+            assertThat(cookie).contains("HttpOnly");
+            assertThat(cookie).contains("SameSite=Strict");
+        });
+    }
+
+    @Test
+    @DisplayName("쿠키 삭제 시에도 동일한 보안 속성을 유지한다")
+    void deleteCookie_preservesSecurityAttributes() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        cookieManager.deleteCookie(response, "access_token");
+
+        String cookie = response.getHeader(HttpHeaders.SET_COOKIE);
+        assertThat(cookie).contains("access_token=");
+        assertThat(cookie).contains("Max-Age=0");
+        assertThat(cookie).contains("Secure");
+        assertThat(cookie).contains("HttpOnly");
+        assertThat(cookie).contains("SameSite=Strict");
+    }
+}


### PR DESCRIPTION

## 요약

인증 모듈 내 쿠키 보안 설정을 강화하고, 액세스 토큰 갱신 버퍼 등 주요 수치를 외부 설정을 통해 유연하게 관리할 수 있도록 개선함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `CookieProperties` 클래스를 추가하여 `secure` 속성 및 `accessTokenRefreshBufferMs` 설정을 외부 프로퍼티화함
* `application.yml` 및 `application-prod.yml`에 환경별 쿠키 보안 및 토큰 버퍼 설정값 추가
* `CookieManager`가 정해진 상수가 아닌 `CookieProperties`를 주입받아 쿠키를 생성 및 삭제하도록 리팩토링
* 쿠키의 보안 속성 및 버퍼 동작을 검증하기 위한 `CookieManagerTest` 유닛 테스트 클래스 추가

## 주요 효과

* 운영 환경(Production)과 개발 환경별로 쿠키의 보안 속성(Secure 등)을 다르게 적용할 수 있어 보안성 향상
* 액세스 토큰 만료 전 여유 시간을 두는 버퍼 설정을 통해 인증 만료로 인한 사용자 경험 저하 방지
* 외부 설정 도입으로 코드 수정 없이 인증 정책(버퍼 시간 등)을 변경할 수 있어 유지보수 편의성 증대

