### PR TITLE
Fix Spring Security role authority prefix

### DIFF
--- a/src/main/java/com/eventitta/auth/domain/UserPrincipal.java
+++ b/src/main/java/com/eventitta/auth/domain/UserPrincipal.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 @Getter
 public class UserPrincipal implements UserDetails {
+    private static final String ROLE_PREFIX = "ROLE_";
+
     private final Long id;
     private final String email;
     private final String password;
@@ -20,14 +22,14 @@ public class UserPrincipal implements UserDetails {
         this.id = user.getId();
         this.email = user.getEmail();
         this.password = user.getPassword();
-        this.authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
+        this.authorities = List.of(new SimpleGrantedAuthority(normalizeRole(user.getRole().name())));
     }
 
     public UserPrincipal(Long id, String email, String role) {
         this.id = id;
         this.email = email;
         this.password = null;
-        this.authorities = List.of(new SimpleGrantedAuthority(role));
+        this.authorities = List.of(new SimpleGrantedAuthority(normalizeRole(role)));
     }
 
     @Override
@@ -63,5 +65,12 @@ public class UserPrincipal implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    private String normalizeRole(String role) {
+        if (role.startsWith(ROLE_PREFIX)) {
+            return role;
+        }
+        return ROLE_PREFIX + role;
     }
 }

--- a/src/test/java/com/eventitta/auth/domain/UserPrincipalTest.java
+++ b/src/test/java/com/eventitta/auth/domain/UserPrincipalTest.java
@@ -1,0 +1,30 @@
+package com.eventitta.auth.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserPrincipalTest {
+
+    @Test
+    @DisplayName("role prefix가 없으면 ROLE_ 접두어를 붙여 권한을 만든다")
+    void constructor_addsRolePrefixWhenMissing() {
+        UserPrincipal principal = new UserPrincipal(1L, "user@test.com", "USER");
+
+        assertThat(principal.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .containsExactly("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("이미 ROLE_ prefix가 있으면 그대로 유지한다")
+    void constructor_keepsExistingRolePrefix() {
+        UserPrincipal principal = new UserPrincipal(1L, "admin@test.com", "ROLE_ADMIN");
+
+        assertThat(principal.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .containsExactly("ROLE_ADMIN");
+    }
+}


### PR DESCRIPTION


## 요약

`UserPrincipal` 클래스에서 사용자 권한(Role) 처리 시 Spring Security와의 호환성을 위해 `ROLE_` 접두사를 일관되게 부여하도록 로직을 개선하고 검증 테스트를 추가함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `UserPrincipal` 내부에 프라이빗 메서드 `normalizeRole`을 추가하여 모든 권한 명칭에 `ROLE_` 접두사가 붙도록 정규화 로직 구현
* 클래스 생성자에서 권한 리스트를 처리할 때 `normalizeRole`을 반드시 거치도록 업데이트하여 데이터 일관성 확보
* `UserPrincipalTest` 클래스를 신규 생성하여 접두사가 없는 권한에 접두사가 잘 추가되는지, 이미 있는 경우 중복되지 않는지 확인하는 테스트 케이스 작성

## 주요 효과

* Spring Security의 권한 검증 표준인 `ROLE_` 접두사 규칙을 준수하여 `hasRole()` 등 보안 설정과의 완벽한 호환성 보장
* 권한 명칭의 형식을 강제함으로써 휴먼 에러로 인한 인가(Authorization) 오류 가능성 원천 차단
* 단위 테스트를 통해 권한 처리 로직의 안정성을 확보하고 향후 유지보수 시 발생할 수 있는 사이드 이펙트 방지
