### PR TITLE
Invalidate refresh tokens on withdrawal

### DIFF
--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.eventitta.user.service;
 
+import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
     public UserProfileResponse getProfile(Long userId) {
@@ -49,8 +51,8 @@ public class UserService {
         User user = userRepository.findActiveById(userId)
             .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
         user.delete();
+        refreshTokenRepository.deleteByUserId(userId);
         // TODO: 탈퇴 정책 후처리 반영 필요
-        // - 리프레시 토큰 전체 삭제
         // - 사용자가 리더인 모임의 리더 위임 또는 종료 처리
         // - 랭킹/캐시에서 사용자 제거
     }

--- a/src/test/java/com/eventitta/user/service/UserServiceTest.java
+++ b/src/test/java/com/eventitta/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.eventitta.user.service;
 
+import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.user.domain.Provider;
 import com.eventitta.user.domain.Role;
 import com.eventitta.user.domain.User;
@@ -31,6 +32,8 @@ class UserServiceTest {
 
     @Mock
     UserRepository userRepository;
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
     @Mock
     PasswordEncoder passwordEncoder;
 
@@ -146,6 +149,7 @@ class UserServiceTest {
         assertThat(user.getAddress()).isNull();
         assertThat(user.getLatitude()).isNull();
         assertThat(user.getLongitude()).isNull();
+        verify(refreshTokenRepository).deleteByUserId(1L);
     }
 
     @Test


### PR DESCRIPTION

## 요약

사용자 계정 삭제 시 해당 사용자와 연관된 모든 리프레시 토큰을 함께 제거하도록 로직을 개선하고, 이를 검증하는 테스트를 추가함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `UserService.deleteUser` 메서드 내에서 사용자 삭제와 동시에 관련 리프레시 토큰을 모두 삭제하는 로직 추가
* 리프레시 토큰 관리를 위해 `UserService`에 `RefreshTokenRepository` 의존성 주입 및 생성자 업데이트
* `UserServiceTest`에서 `RefreshTokenRepository`를 모킹(Mock)하고, 사용자 삭제 시 토큰 삭제 메서드가 호출되는지 확인하는 검증 로직 추가
* 테스트 코드 내 필요한 리포지토리 임포트 구문 추가

## 주요 효과

* 사용자가 탈퇴하거나 삭제된 후에도 리프레시 토큰이 유효하게 남아 발생할 수 있는 보안 취약점을 제거함
* 사용자 엔티티와 인증 토큰의 생명주기를 동기화하여 데이터베이스 및 인증 시스템의 무결성을 높임

