### PR TITLE
fix(auth): revoke refresh tokens on user withdrawal

### DIFF
--- a/src/main/java/com/eventitta/user/service/UserService.java
+++ b/src/main/java/com/eventitta/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.eventitta.user.service;
 
+import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.dto.ChangePasswordRequest;
 import com.eventitta.user.dto.UpdateProfileRequest;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
     public UserProfileResponse getProfile(Long userId) {
@@ -49,8 +51,8 @@ public class UserService {
         User user = userRepository.findActiveById(userId)
             .orElseThrow(UserErrorCode.NOT_FOUND_USER_ID::defaultException);
         user.delete();
+        refreshTokenRepository.deleteByUserId(userId);
         // TODO: 탈퇴 정책 후처리 반영 필요
-        // - 리프레시 토큰 전체 삭제
         // - 사용자가 리더인 모임의 리더 위임 또는 종료 처리
         // - 랭킹/캐시에서 사용자 제거
     }

--- a/src/test/java/com/eventitta/user/service/UserServiceTest.java
+++ b/src/test/java/com/eventitta/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.eventitta.user.service;
 
+import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.user.domain.Provider;
 import com.eventitta.user.domain.Role;
 import com.eventitta.user.domain.User;
@@ -31,6 +32,8 @@ class UserServiceTest {
 
     @Mock
     UserRepository userRepository;
+    @Mock
+    RefreshTokenRepository refreshTokenRepository;
     @Mock
     PasswordEncoder passwordEncoder;
 
@@ -146,6 +149,7 @@ class UserServiceTest {
         assertThat(user.getAddress()).isNull();
         assertThat(user.getLatitude()).isNull();
         assertThat(user.getLongitude()).isNull();
+        verify(refreshTokenRepository).deleteByUserId(1L);
     }
 
     @Test


### PR DESCRIPTION

## 요약

사용자 삭제 시 해당 사용자와 연관된 모든 리프레시 토큰을 함께 삭제하도록 로직을 개선하고, 이에 대한 검증 테스트를 추가함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `UserService.java`: `RefreshTokenRepository` 의존성을 추가하고, `deleteUser` 메서드 호출 시 사용자의 리프레시 토큰을 모두 제거하는 로직 구현
* `UserServiceTest.java`: `RefreshTokenRepository` 모킹(Mock) 추가 및 `deleteUser_mutatesIdentifiersAndClearsPersonalData` 테스트 케이스에서 토큰 삭제 여부를 검증하도록 업데이트

## 주요 효과

* 계정이 삭제된 사용자의 리프레시 토큰이 시스템에 남아 발생할 수 있는 잠재적인 보안 위협을 사전에 차단함
* 사용자 엔티티의 삭제와 인증 세션(토큰)의 만료를 동기화하여 데이터 및 인증 상태의 일관성을 확보함

