### PR TITLE
fix(auth): map signup unique violations to conflict errors

### DIFF
--- a/src/main/java/com/eventitta/auth/service/SignUpService.java
+++ b/src/main/java/com/eventitta/auth/service/SignUpService.java
@@ -4,9 +4,12 @@ import com.eventitta.auth.service.dto.SignUpCommand;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
 
 import static com.eventitta.user.exception.UserErrorCode.CONFLICTED_EMAIL;
 import static com.eventitta.user.exception.UserErrorCode.CONFLICTED_NICKNAME;
@@ -22,6 +25,35 @@ public class SignUpService {
         if (userRepository.existsByEmail(command.email())) throw CONFLICTED_EMAIL.defaultException();
         if (userRepository.existsByNickname(command.nickname())) throw CONFLICTED_NICKNAME.defaultException();
         User user = command.toEntity(passwordEncoder);
-        return userRepository.save(user);
+        try {
+            return userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException ex) {
+            throw mapSignupConflict(ex);
+        }
+    }
+
+    private RuntimeException mapSignupConflict(DataIntegrityViolationException ex) {
+        String message = extractExceptionMessage(ex);
+        if (message.contains("uk_users_email") || message.contains("users.email")) {
+            return CONFLICTED_EMAIL.defaultException(ex);
+        }
+        if (message.contains("uk_users_nickname") || message.contains("users.nickname")) {
+            return CONFLICTED_NICKNAME.defaultException(ex);
+        }
+        throw ex;
+    }
+
+    private String extractExceptionMessage(Throwable throwable) {
+        StringBuilder builder = new StringBuilder();
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current.getMessage() != null) {
+                builder.append(current.getMessage()).append(' ');
+            }
+            current = current.getCause();
+        }
+
+        return builder.toString().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -9,7 +9,6 @@ import com.eventitta.auth.service.dto.RefreshCommand;
 import com.eventitta.auth.service.dto.SignInCommand;
 import com.eventitta.auth.service.dto.SignUpCommand;
 import com.eventitta.auth.service.dto.SignUpResult;
-import com.eventitta.notification.domain.AlertLevel;
 import com.eventitta.notification.resolver.AlertLevelResolver;
 import com.eventitta.notification.service.DiscordNotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -89,13 +88,12 @@ class AuthControllerTest {
         }
 
         @Test
-        @DisplayName("회원가입 중 DB unique constraint 안전장치가 동작하면 500 에러와 Discord 알림을 남긴다")
+        @DisplayName("회원가입 중 unique 충돌이 발생하면 409 에러를 반환한다")
         void signUp_fail_when_duplicate_resource_detected_at_database() throws Exception {
             // given
             SignUpRequest signupReq = new SignUpRequest("test@gmail.com", "password1234!@@", "test123");
-            given(userInfoService.getCurrentUserInfo()).willReturn("user-1");
             given(authService.signUp(signupReq.toCommand()))
-                .willThrow(new DataIntegrityViolationException("duplicate key"));
+                .willThrow(CONFLICTED_EMAIL.defaultException());
 
             // when & then
             mockMvc.perform(
@@ -103,19 +101,9 @@ class AuthControllerTest {
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(signupReq))
                 )
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.error").value("INTERNAL_ERROR"))
-                .andExpect(jsonPath("$.message").value("예상치 못한 서버 오류가 발생했습니다."));
-
-            then(discordNotificationService).should().sendAlert(
-                eq(AlertLevel.HIGH),
-                eq("INTERNAL_ERROR"),
-                eq("예상치 못한 서버 오류가 발생했습니다."),
-                eq("/api/v1/auth/signup"),
-                eq("user-1"),
-                any(DataIntegrityViolationException.class)
-            );
-            then(alertLevelResolver).shouldHaveNoInteractions();
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("CONFLICTED_EMAIL"))
+                .andExpect(jsonPath("$.message").value(CONFLICTED_EMAIL.defaultMessage()));
         }
 
         @Test

--- a/src/test/java/com/eventitta/auth/service/SignUpServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/SignUpServiceTest.java
@@ -14,7 +14,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,14 +49,14 @@ class SignUpServiceTest {
         when(passwordEncoder.encode(command.password())).thenReturn("encoded-password");
 
         User savedUser = mock(User.class);
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userRepository.saveAndFlush(any(User.class))).thenReturn(savedUser);
 
         // when
         User result = signUpService.register(command);
 
         // then
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-        verify(userRepository).save(userCaptor.capture());
+        verify(userRepository).saveAndFlush(userCaptor.capture());
 
         User user = userCaptor.getValue();
         assertThat(user.getEmail()).isEqualTo(command.email());
@@ -87,7 +89,7 @@ class SignUpServiceTest {
         assertThat(((UserException) thrown).getErrorCode()).isEqualTo(UserErrorCode.CONFLICTED_EMAIL);
 
         verify(userRepository, never()).existsByNickname(anyString());
-        verify(userRepository, never()).save(any(User.class));
+        verify(userRepository, never()).saveAndFlush(any(User.class));
     }
 
     @Test
@@ -110,6 +112,48 @@ class SignUpServiceTest {
         assertThat(thrown).isInstanceOf(UserException.class);
         assertThat(((UserException) thrown).getErrorCode()).isEqualTo(UserErrorCode.CONFLICTED_NICKNAME);
 
-        verify(userRepository, never()).save(any(User.class));
+        verify(userRepository, never()).saveAndFlush(any(User.class));
+    }
+
+    @Test
+    @DisplayName("저장 시 이메일 unique constraint 위반이 발생하면 중복 이메일 예외로 변환한다.")
+    void register_fail_when_email_unique_violation_occurs_on_save() {
+        SignUpCommand command = new SignUpCommand(
+            "test@example.com",
+            "rawPassword",
+            "tester"
+        );
+
+        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByNickname(command.nickname())).thenReturn(false);
+        when(passwordEncoder.encode(command.password())).thenReturn("encoded-password");
+        when(userRepository.saveAndFlush(any(User.class)))
+            .thenThrow(new DataIntegrityViolationException("Duplicate entry for key 'uk_users_email'"));
+
+        Throwable thrown = catchThrowable(() -> signUpService.register(command));
+
+        assertThat(thrown).isInstanceOf(UserException.class);
+        assertThat(((UserException) thrown).getErrorCode()).isEqualTo(UserErrorCode.CONFLICTED_EMAIL);
+    }
+
+    @Test
+    @DisplayName("저장 시 닉네임 unique constraint 위반이 발생하면 중복 닉네임 예외로 변환한다.")
+    void register_fail_when_nickname_unique_violation_occurs_on_save() {
+        SignUpCommand command = new SignUpCommand(
+            "test@example.com",
+            "rawPassword",
+            "tester"
+        );
+
+        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByNickname(command.nickname())).thenReturn(false);
+        when(passwordEncoder.encode(command.password())).thenReturn("encoded-password");
+        when(userRepository.saveAndFlush(any(User.class)))
+            .thenThrow(new DataIntegrityViolationException("Duplicate entry for key 'uk_users_nickname'"));
+
+        Throwable thrown = catchThrowable(() -> signUpService.register(command));
+
+        assertThat(thrown).isInstanceOf(UserException.class);
+        assertThat(((UserException) thrown).getErrorCode()).isEqualTo(UserErrorCode.CONFLICTED_NICKNAME);
     }
 }


### PR DESCRIPTION

## 요약

회원가입 시 발생하는 이메일 및 닉네임 중복(DB 제약 조건 위반) 예외를 구체적인 비즈니스 예외로 매핑하여 명확한 에러 응답을 제공하도록 개선함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `SignUpService`에서 `DataIntegrityViolationException`을 포착하여 `CONFLICTED_EMAIL` 또는 `CONFLICTED_NICKNAME` 예외로 변환하는 로직 구현
* 예외 메시지에서 충돌 원인을 정확히 추출하기 위한 헬퍼 메서드(`mapSignupConflict`, `extractExceptionMessage`) 추가
* 중복 발생 시 기존 500 에러 대신 409 Conflict 응답과 전용 에러 코드를 반환하도록 컨트롤러 테스트 수정
* 불필요한 알림 수준(`AlertLevel`) 임포트 제거 및 누락된 예외 클래스 임포트 추가

## 주요 효과

* 클라이언트에게 중복된 필드(이메일 또는 닉네임)를 구체적으로 안내하여 사용자 경험(UX) 향상
* 단순 비즈니스 충돌 상황에 대한 불필요한 서버 알림을 억제하여 운영 모니터링의 효율성 증대
* 예외 처리 흐름을 표준화하여 향후 다른 제약 조건 위반 상황에 대해서도 일관된 대응 구조 마련

