### PR TITLE
fix(auth): align refresh with expired access token cookie

### DIFF
--- a/src/main/java/com/eventitta/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/eventitta/auth/jwt/JwtTokenProvider.java
@@ -87,6 +87,8 @@ public class JwtTokenProvider {
             return getUserId(token);
         } catch (ExpiredJwtException e) {
             return Long.parseLong(e.getClaims().getSubject());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw ACCESS_TOKEN_INVALID.defaultException(e);
         }
     }
 

--- a/src/main/java/com/eventitta/auth/properties/CookieProperties.java
+++ b/src/main/java/com/eventitta/auth/properties/CookieProperties.java
@@ -11,5 +11,4 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "cookie")
 public class CookieProperties {
     private boolean secure = false;
-    private long accessTokenRefreshBufferMs = 300_000L;
 }

--- a/src/main/java/com/eventitta/auth/service/CookieManager.java
+++ b/src/main/java/com/eventitta/auth/service/CookieManager.java
@@ -51,8 +51,7 @@ public class CookieManager {
     }
 
     private ResponseCookie createAccessTokenCookie(String value) {
-        long validityMs = tokenProvider.getAccessTokenValidityMs() + cookieProperties.getAccessTokenRefreshBufferMs();
-        return createCookie(ACCESS_TOKEN, value, validityMs);
+        return createCookie(ACCESS_TOKEN, value, tokenProvider.getRefreshTokenValidityMs());
     }
 
     private ResponseCookie createRefreshTokenCookie(String value) {

--- a/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
@@ -30,15 +30,16 @@ public class RefreshTokenService {
             throw REFRESH_TOKEN_MISSING.defaultException();
         }
 
-        LocalDateTime now = LocalDateTime.now(clock);
         RefreshToken entity = resolveRefreshToken(command);
+        LocalDateTime now = LocalDateTime.now(clock);
 
         if (entity.getExpiresAt().isBefore(now)) {
             throw REFRESH_TOKEN_EXPIRED.defaultException();
         }
 
+        Long userId = entity.getUser().getId();
         rtRepo.delete(entity);
-        return tokenService.issueTokens(entity.getUser().getId());
+        return tokenService.issueTokens(userId);
     }
 
     public void invalidateByToken(String accessToken, String refreshToken) {
@@ -53,7 +54,7 @@ public class RefreshTokenService {
 
     private RefreshToken resolveRefreshToken(RefreshCommand command) {
         if (command.accessToken() == null || command.accessToken().isBlank()) {
-            throw REFRESH_TOKEN_INVALID.defaultException();
+            throw ACCESS_TOKEN_INVALID.defaultException();
         }
 
         Long userId = tokenProvider.getUserIdFromExpiredToken(command.accessToken());

--- a/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/eventitta/auth/service/RefreshTokenService.java
@@ -26,27 +26,19 @@ public class RefreshTokenService {
     private final Clock clock;
 
     public TokenResult refresh(RefreshCommand command) {
-        if (command.accessToken() == null || command.accessToken().isBlank()) {
-            throw ACCESS_TOKEN_INVALID.defaultException();
-        }
         if (command.refreshToken() == null || command.refreshToken().isBlank()) {
             throw REFRESH_TOKEN_MISSING.defaultException();
         }
 
-        Long userId = tokenProvider.getUserIdFromExpiredToken(command.accessToken());
+        LocalDateTime now = LocalDateTime.now(clock);
+        RefreshToken entity = resolveRefreshToken(command);
 
-        RefreshToken entity = rtRepo.findAllByUserId(userId)
-            .stream()
-            .filter(token -> rtEncoder.matches(command.refreshToken(), token.getTokenHash()))
-            .findFirst()
-            .orElseThrow(REFRESH_TOKEN_INVALID::defaultException);
-
-        if (entity.getExpiresAt().isBefore(LocalDateTime.now(clock))) {
+        if (entity.getExpiresAt().isBefore(now)) {
             throw REFRESH_TOKEN_EXPIRED.defaultException();
         }
 
         rtRepo.delete(entity);
-        return tokenService.issueTokens(userId);
+        return tokenService.issueTokens(entity.getUser().getId());
     }
 
     public void invalidateByToken(String accessToken, String refreshToken) {
@@ -57,5 +49,18 @@ public class RefreshTokenService {
             .filter(token -> rtEncoder.matches(refreshToken, token.getTokenHash()))
             .findFirst()
             .ifPresent(rtRepo::delete);
+    }
+
+    private RefreshToken resolveRefreshToken(RefreshCommand command) {
+        if (command.accessToken() == null || command.accessToken().isBlank()) {
+            throw REFRESH_TOKEN_INVALID.defaultException();
+        }
+
+        Long userId = tokenProvider.getUserIdFromExpiredToken(command.accessToken());
+        return rtRepo.findAllByUserId(userId)
+            .stream()
+            .filter(token -> rtEncoder.matches(command.refreshToken(), token.getTokenHash()))
+            .findFirst()
+            .orElseThrow(REFRESH_TOKEN_INVALID::defaultException);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,3 @@ monitoring:
 
 cookie:
   secure: false
-  access-token-refresh-buffer-ms: 300000

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -385,6 +385,24 @@ class AuthControllerTest {
         }
 
         @Test
+        @DisplayName("access token 쿠키가 없으면 401 에러 응답을 반환한다")
+        void refresh_fail_when_access_token_is_missing() throws Exception {
+            willThrow(REFRESH_TOKEN_INVALID.defaultException())
+                .given(authService)
+                .refresh(any(RefreshCommand.class), any(HttpServletResponse.class));
+
+            mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                        .cookie(new Cookie(REFRESH_TOKEN, "valid-refresh-token"))
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("REFRESH_TOKEN_INVALID"));
+
+            then(authService).should()
+                .refresh(eq(new RefreshCommand(null, "valid-refresh-token")), any(HttpServletResponse.class));
+        }
+
+        @Test
         @DisplayName("리프레시 토큰이 없으면 400 에러 응답을 반환한다")
         void refresh_fail_when_refresh_token_is_missing() throws Exception {
             // given

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -387,7 +387,7 @@ class AuthControllerTest {
         @Test
         @DisplayName("access token 쿠키가 없으면 401 에러 응답을 반환한다")
         void refresh_fail_when_access_token_is_missing() throws Exception {
-            willThrow(REFRESH_TOKEN_INVALID.defaultException())
+            willThrow(ACCESS_TOKEN_INVALID.defaultException())
                 .given(authService)
                 .refresh(any(RefreshCommand.class), any(HttpServletResponse.class));
 
@@ -396,7 +396,7 @@ class AuthControllerTest {
                         .cookie(new Cookie(REFRESH_TOKEN, "valid-refresh-token"))
                 )
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.error").value("REFRESH_TOKEN_INVALID"));
+                .andExpect(jsonPath("$.error").value("ACCESS_TOKEN_INVALID"));
 
             then(authService).should()
                 .refresh(eq(new RefreshCommand(null, "valid-refresh-token")), any(HttpServletResponse.class));

--- a/src/test/java/com/eventitta/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/eventitta/auth/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,66 @@
+package com.eventitta.auth.jwt;
+
+import com.eventitta.auth.exception.AuthErrorCode;
+import com.eventitta.auth.exception.AuthException;
+import com.eventitta.auth.properties.JwtProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+    @Test
+    @DisplayName("만료된 access token 에서도 사용자 ID를 추출한다")
+    void getUserIdFromExpiredToken_returnsUserIdForExpiredToken() {
+        Instant issuedAt = Instant.parse("2026-03-15T00:00:00Z");
+        JwtTokenProvider issuer = new JwtTokenProvider(jwtProperties(), Clock.fixed(issuedAt, ZoneOffset.UTC));
+        String expiredAccessToken = issuer.createAccessToken(1L, "spring@test.com", "USER");
+
+        JwtTokenProvider parser = new JwtTokenProvider(
+            jwtProperties(),
+            Clock.fixed(issuedAt.plusSeconds(2), ZoneOffset.UTC)
+        );
+
+        Long userId = parser.getUserIdFromExpiredToken(expiredAccessToken);
+
+        assertThat(userId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("서명이 변조된 access token 은 ACCESS_TOKEN_INVALID 예외를 던진다")
+    void getUserIdFromExpiredToken_throwsAuthExceptionForTamperedToken() {
+        JwtTokenProvider provider = new JwtTokenProvider(
+            jwtProperties(),
+            Clock.fixed(Instant.parse("2026-03-15T00:00:00Z"), ZoneOffset.UTC)
+        );
+        String accessToken = provider.createAccessToken(1L, "spring@test.com", "USER");
+        String tamperedAccessToken = tamperSignature(accessToken);
+
+        assertThatThrownBy(() -> provider.getUserIdFromExpiredToken(tamperedAccessToken))
+            .isInstanceOf(AuthException.class)
+            .extracting("errorCode")
+            .isEqualTo(AuthErrorCode.ACCESS_TOKEN_INVALID);
+    }
+
+    private JwtProperties jwtProperties() {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret("0123456789abcdef0123456789abcdef0123456789abcdef");
+        properties.setAccessTokenValidityMs(1_000L);
+        properties.setRefreshTokenValidityMs(86_400_000L);
+        return properties;
+    }
+
+    private String tamperSignature(String token) {
+        String[] parts = token.split("\\.");
+        String signature = parts[2];
+        char replacement = signature.charAt(signature.length() - 1) == 'a' ? 'b' : 'a';
+        parts[2] = signature.substring(0, signature.length() - 1) + replacement;
+        return String.join(".", parts);
+    }
+}

--- a/src/test/java/com/eventitta/auth/service/CookieManagerTest.java
+++ b/src/test/java/com/eventitta/auth/service/CookieManagerTest.java
@@ -29,14 +29,12 @@ class CookieManagerTest {
     void setUp() {
         CookieProperties cookieProperties = new CookieProperties();
         cookieProperties.setSecure(true);
-        cookieProperties.setAccessTokenRefreshBufferMs(300_000L);
         cookieManager = new CookieManager(tokenProvider, cookieProperties);
     }
 
     @Test
-    @DisplayName("토큰 쿠키를 저장할 때 운영 보안 속성과 access token refresh 버퍼를 적용한다")
-    void addTokenCookies_appliesSecureFlagAndAccessTokenBuffer() {
-        given(tokenProvider.getAccessTokenValidityMs()).willReturn(3_600_000L);
+    @DisplayName("토큰 쿠키를 저장할 때 access token 쿠키도 refresh token 수명만큼 유지한다")
+    void addTokenCookies_usesRefreshTokenLifetimeForBothCookies() {
         given(tokenProvider.getRefreshTokenValidityMs()).willReturn(86_400_000L);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -47,7 +45,7 @@ class CookieManagerTest {
         assertThat(cookies).hasSize(2);
         assertThat(cookies).anySatisfy(cookie -> {
             assertThat(cookie).contains("access_token=access-token");
-            assertThat(cookie).contains("Max-Age=3900");
+            assertThat(cookie).contains("Max-Age=86400");
             assertThat(cookie).contains("Secure");
             assertThat(cookie).contains("HttpOnly");
             assertThat(cookie).contains("SameSite=Strict");

--- a/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
@@ -16,6 +16,7 @@ import com.eventitta.auth.jwt.JwtTokenProvider;
 import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.auth.service.dto.RefreshCommand;
 import com.eventitta.auth.service.dto.TokenResult;
+import com.eventitta.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,14 +51,20 @@ class RefreshTokenServiceTest {
         private static final LocalDateTime FIXED_NOW = LocalDateTime.ofInstant(FIXED_INSTANT, FIXED_ZONE);
 
         @Test
-        @DisplayName("액세스 토큰이 비어 있으면 토큰을 재발급할 수 없다.")
-        void refresh_whenAccessTokenIsBlank_thenThrowsException() {
+        @DisplayName("액세스 토큰이 null 이면 토큰을 재발급할 수 없다.")
+        void refresh_whenAccessTokenIsNull_thenThrowsException() {
             // given
-            RefreshCommand command = new RefreshCommand(" ", "refresh-token");
+            RefreshCommand command = new RefreshCommand(null, "refresh-token");
+            given(clock.instant()).willReturn(FIXED_INSTANT);
+            given(clock.getZone()).willReturn(FIXED_ZONE);
 
             // when // then
             assertThatThrownBy(() -> refreshTokenService.refresh(command))
                 .isInstanceOf(AuthException.class);
+
+            then(tokenProvider).shouldHaveNoInteractions();
+            then(rtRepo).shouldHaveNoInteractions();
+            then(tokenService).shouldHaveNoInteractions();
         }
 
         @Test
@@ -78,6 +85,8 @@ class RefreshTokenServiceTest {
             Long userId = 1L;
             RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
             RefreshToken tokenEntity = mock(RefreshToken.class);
+            given(clock.instant()).willReturn(FIXED_INSTANT);
+            given(clock.getZone()).willReturn(FIXED_ZONE);
 
             given(tokenProvider.getUserIdFromExpiredToken(command.accessToken())).willReturn(userId);
             given(rtRepo.findAllByUserId(userId)).willReturn(List.of(tokenEntity));
@@ -90,6 +99,24 @@ class RefreshTokenServiceTest {
 
             then(rtRepo).should(never()).delete(tokenEntity);
             then(tokenService).should(never()).issueTokens(anyLong());
+        }
+
+        @Test
+        @DisplayName("액세스 토큰이 손상되면 토큰을 재발급할 수 없다.")
+        void refresh_whenAccessTokenIsInvalid_thenThrowsException() {
+            // given
+            RefreshCommand command = new RefreshCommand("malformed-access-token", "refresh-token");
+            given(clock.instant()).willReturn(FIXED_INSTANT);
+            given(clock.getZone()).willReturn(FIXED_ZONE);
+            given(tokenProvider.getUserIdFromExpiredToken(command.accessToken()))
+                .willThrow(com.eventitta.auth.exception.AuthErrorCode.ACCESS_TOKEN_INVALID.defaultException());
+
+            // when // then
+            assertThatThrownBy(() -> refreshTokenService.refresh(command))
+                .isInstanceOf(AuthException.class);
+
+            then(rtRepo).shouldHaveNoInteractions();
+            then(tokenService).shouldHaveNoInteractions();
         }
 
         @Test
@@ -123,6 +150,7 @@ class RefreshTokenServiceTest {
             Long userId = 1L;
             RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
             RefreshToken tokenEntity = mock(RefreshToken.class);
+            User user = mock(User.class);
             TokenResult reissuedTokens = new TokenResult("new-access-token", "new-refresh-token");
             given(clock.instant()).willReturn(FIXED_INSTANT);
             given(clock.getZone()).willReturn(FIXED_ZONE);
@@ -132,6 +160,8 @@ class RefreshTokenServiceTest {
             given(tokenEntity.getTokenHash()).willReturn("stored-hash");
             given(rtEncoder.matches(command.refreshToken(), "stored-hash")).willReturn(true);
             given(tokenEntity.getExpiresAt()).willReturn(FIXED_NOW.plusMinutes(30));
+            given(tokenEntity.getUser()).willReturn(user);
+            given(user.getId()).willReturn(userId);
             given(tokenService.issueTokens(userId)).willReturn(reissuedTokens);
 
             // when
@@ -150,6 +180,7 @@ class RefreshTokenServiceTest {
             Long userId = 1L;
             RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
             RefreshToken tokenEntity = mock(RefreshToken.class);
+            User user = mock(User.class);
             TokenResult reissuedTokens = new TokenResult("new-access-token", "new-refresh-token");
             given(clock.instant()).willReturn(FIXED_INSTANT);
             given(clock.getZone()).willReturn(FIXED_ZONE);
@@ -159,6 +190,8 @@ class RefreshTokenServiceTest {
             given(tokenEntity.getTokenHash()).willReturn("stored-hash");
             given(rtEncoder.matches(command.refreshToken(), "stored-hash")).willReturn(true);
             given(tokenEntity.getExpiresAt()).willReturn(FIXED_NOW);
+            given(tokenEntity.getUser()).willReturn(user);
+            given(user.getId()).willReturn(userId);
             given(tokenService.issueTokens(userId)).willReturn(reissuedTokens);
 
             // when

--- a/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/RefreshTokenServiceTest.java
@@ -55,12 +55,12 @@ class RefreshTokenServiceTest {
         void refresh_whenAccessTokenIsNull_thenThrowsException() {
             // given
             RefreshCommand command = new RefreshCommand(null, "refresh-token");
-            given(clock.instant()).willReturn(FIXED_INSTANT);
-            given(clock.getZone()).willReturn(FIXED_ZONE);
 
             // when // then
             assertThatThrownBy(() -> refreshTokenService.refresh(command))
-                .isInstanceOf(AuthException.class);
+                .isInstanceOf(AuthException.class)
+                .extracting("errorCode")
+                .isEqualTo(com.eventitta.auth.exception.AuthErrorCode.ACCESS_TOKEN_INVALID);
 
             then(tokenProvider).shouldHaveNoInteractions();
             then(rtRepo).shouldHaveNoInteractions();
@@ -75,7 +75,9 @@ class RefreshTokenServiceTest {
 
             // when // then
             assertThatThrownBy(() -> refreshTokenService.refresh(command))
-                .isInstanceOf(AuthException.class);
+                .isInstanceOf(AuthException.class)
+                .extracting("errorCode")
+                .isEqualTo(com.eventitta.auth.exception.AuthErrorCode.REFRESH_TOKEN_MISSING);
         }
 
         @Test
@@ -85,8 +87,6 @@ class RefreshTokenServiceTest {
             Long userId = 1L;
             RefreshCommand command = new RefreshCommand("expired-access-token", "refresh-token");
             RefreshToken tokenEntity = mock(RefreshToken.class);
-            given(clock.instant()).willReturn(FIXED_INSTANT);
-            given(clock.getZone()).willReturn(FIXED_ZONE);
 
             given(tokenProvider.getUserIdFromExpiredToken(command.accessToken())).willReturn(userId);
             given(rtRepo.findAllByUserId(userId)).willReturn(List.of(tokenEntity));
@@ -106,8 +106,6 @@ class RefreshTokenServiceTest {
         void refresh_whenAccessTokenIsInvalid_thenThrowsException() {
             // given
             RefreshCommand command = new RefreshCommand("malformed-access-token", "refresh-token");
-            given(clock.instant()).willReturn(FIXED_INSTANT);
-            given(clock.getZone()).willReturn(FIXED_ZONE);
             given(tokenProvider.getUserIdFromExpiredToken(command.accessToken()))
                 .willThrow(com.eventitta.auth.exception.AuthErrorCode.ACCESS_TOKEN_INVALID.defaultException());
 


### PR DESCRIPTION

## 요약

인증 토큰 재발급 로직의 리팩토링과 에러 처리 강화, 그리고 쿠키 관리 방식을 개선하여 시스템의 안정성과 보안성을 높임.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* `RefreshTokenService.refresh()` 메서드 리팩토링 및 토큰 검증 로직을 `resolveRefreshToken` 프라이빗 메서드로 분리하여 가독성 개선
* 액세스 토큰 누락 시 `REFRESH_TOKEN_INVALID` 예외를 발생시키고, 토큰 발급 시 `entity.getUser().getId()`를 사용하도록 식별 로직 수정
* `JwtTokenProvider`에서 변조되거나 잘못된 형식의 토큰에 대해 `ACCESS_TOKEN_INVALID` 예외를 던지도록 에러 핸들링 고도화
* 액세스 토큰 쿠키의 유효 기간을 리프레시 토큰 수명과 동기화하여 쿠키 관리 정책의 일관성 확보
* 토큰 추출, 변조된 토큰 예외 처리, 쿠키 누락 시나리오(401 응답) 등에 대한 포괄적인 단위 및 컨트롤러 테스트 추가

## 주요 효과

* 리팩토링을 통해 토큰 재발급 로직의 가독성을 높이고 코드 유지보수 비용을 절감함
* 에러 처리의 세분화를 통해 비정상적인 토큰 접근에 대한 보안 대응력 및 디버깅 용이성을 강화함
* 쿠키 수명 정책 통일로 사용자 세션 관리의 예측 가능성을 높이고 불필요한 인증 오류를 방지함

