### PR TITLE
Refactor DTO conversions using MapStruct and update documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,7 @@ com.eventitta/
 │   ├── domain/
 │   ├── service/
 │   ├── controller/
+│   ├── mapper/        # Request/Command, Result/Response 변환
 │   ├── jwt/           # JWT 유틸리티, 필터
 │   └── exception/
 │
@@ -52,6 +53,14 @@ com.eventitta/
     ├── exception/     # GlobalExceptionHandler, CustomException
     └── util/          # CookieUtil
 ```
+
+### DTO 및 Mapper 원칙
+
+- DTO는 소유 계층 기준으로 배치한다.
+- 계층 간 변환은 기본적으로 각 도메인 패키지의 `mapper`에서 `MapStruct`로 처리한다.
+- Controller는 Request/Response를 직접 조립하지 않고 mapper를 통해 Service DTO와 연결한다.
+- Service도 단순 DTO 조립보다는 mapper를 사용하고, 도메인 규칙이나 계산 로직만 직접 가진다.
+- 자세한 규칙은 [DTO_GUIDELINES.md](./DTO_GUIDELINES.md)를 따른다.
 
 ## 엔티티 상속 구조
 

--- a/docs/DTO_GUIDELINES.md
+++ b/docs/DTO_GUIDELINES.md
@@ -9,6 +9,8 @@
 - DTO는 `dto` 폴더에 무분별하게 모으지 않는다.
 - DTO는 "누가 만들고 누가 소비하는가"를 기준으로 배치한다.
 
+계층 간 DTO 변환 구현은 기본적으로 `MapStruct`를 우선한다.
+
 ## 기본 원칙
 
 ### 1. 계층 소유권 기준으로 배치한다
@@ -33,6 +35,8 @@ com.eventitta.auth
 │   │   └── SignUpRequest
 │   └── response
 │       └── SignUpResponse
+├── mapper
+│   └── AuthMapper
 ├── service
 │   └── dto
 │       ├── SignUpCommand
@@ -87,10 +91,36 @@ com.eventitta.auth
 각 계층은 자신의 DTO만 직접 알아야 한다.
 
 - Controller는 Controller DTO를 받는다.
-- Controller는 Service DTO로 변환해서 Service에 전달한다.
+- Controller는 Mapper를 통해 Service DTO로 변환해서 Service에 전달한다.
 - Service는 Service DTO를 반환한다.
-- Controller는 필요한 경우 Service DTO를 Response로 변환한다.
+- Controller는 필요한 경우 Mapper를 통해 Service DTO를 Response로 변환한다.
 - Repository projection은 API 응답으로 직접 노출하지 않는다.
+
+## MapStruct 사용 원칙
+
+계층 간 변환은 수동 생성보다 `MapStruct` 기반 mapper를 기본값으로 둔다.
+
+- Mapper는 각 도메인 패키지 아래 `mapper` 패키지에 둔다.
+- Mapper는 `@Mapper(componentModel = "spring")`를 사용한다.
+- Controller와 Service는 mapper를 생성하지 말고 Spring 빈으로 주입받는다.
+- Request -> Command
+- Result -> Response
+- Entity -> Response
+- Projection -> Response
+- 여러 입력을 조합한 응답 변환
+
+위와 같은 단순 매핑은 DTO의 `static from`, `static of`, `toCommand()` 같은 수동 변환 메서드보다 mapper로 옮기는 것을 우선한다.
+
+## MapStruct를 바로 쓰지 않는 경우
+
+모든 변환을 기계적으로 mapper로 옮기지는 않는다.
+
+- 비밀번호 인코딩처럼 외부 의존성이 직접 개입하는 경우
+- 엔티티 생성 시 기본 role, provider, 상태값 같은 도메인 규칙을 강하게 보장해야 하는 경우
+- 정렬, 집계, 랭킹 계산, 계층 경로 생성처럼 변환보다 계산이 본질인 경우
+- 외부 API 호출, 캐시 탐색, DB 조회 조합이 핵심인 경우
+
+이 경우에도 가능한 순수 필드 매핑 부분만 mapper로 분리하고, 비즈니스 규칙은 Service나 Domain에 남긴다.
 
 ## 회원가입 예시
 
@@ -114,6 +144,7 @@ Client
 - Service가 Controller 전용 DTO를 직접 알지 않는다.
 - Request/Response와 유스케이스 입력/출력을 분리할 수 있다.
 - Projection이 API 계약으로 새어 나가지 않는다.
+- 매핑 규칙이 Mapper에 모여 중복 변환 코드가 줄어든다.
 
 ## 금지 사항
 
@@ -121,6 +152,8 @@ Client
 - Service가 `controller/response` DTO를 직접 반환하지 않는다.
 - Repository projection을 Controller 응답으로 직접 반환하지 않는다.
 - Entity를 Controller 응답 모델로 직접 사용하지 않는다.
+- Controller나 Service에 단순 DTO 조립 코드를 반복해서 작성하지 않는다.
+- 단순 매핑을 위해 DTO에 `from`, `of`, `toCommand` 메서드를 계속 추가하지 않는다.
 
 ## 적용 순서
 
@@ -129,11 +162,12 @@ Client
 1. 현재 작업 중인 기능부터 적용한다.
 2. Request/Response를 Controller 소유 패키지로 이동한다.
 3. Service 입력/출력 모델을 `service/dto`로 분리한다.
-4. 조회 최적화가 필요한 경우 projection을 `repository/projection`으로 분리한다.
-5. 다음 기능으로 같은 규칙을 확장한다.
+4. 계층 간 변환이 있다면 `mapper` 패키지에 MapStruct mapper를 추가하거나 확장한다.
+5. 조회 최적화가 필요한 경우 projection을 `repository/projection`으로 분리한다.
+6. 다음 기능으로 같은 규칙을 확장한다.
 
 ## 현재 기준
 
 현재 Eventitta의 DTO 기준은 아래 문장으로 요약한다.
 
-`DTO는 dto라는 이름보다 소유 계층과 사용 목적이 먼저 드러나야 한다.`
+`DTO는 소유 계층과 사용 목적이 먼저 드러나야 하고, 계층 간 변환은 기본적으로 MapStruct mapper에 모은다.`

--- a/src/main/java/com/eventitta/auth/controller/AuthController.java
+++ b/src/main/java/com/eventitta/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.eventitta.auth.controller;
 import com.eventitta.auth.controller.request.SignInRequest;
 import com.eventitta.auth.controller.request.SignUpRequest;
 import com.eventitta.auth.controller.response.SignUpResponse;
+import com.eventitta.auth.mapper.AuthMapper;
 import com.eventitta.auth.service.AuthService;
 import com.eventitta.auth.service.dto.LogoutCommand;
 import com.eventitta.auth.service.dto.RefreshCommand;
@@ -27,12 +28,13 @@ import static com.eventitta.auth.constants.AuthConstants.REFRESH_TOKEN;
 @Tag(name = "인증 API", description = "회원가입, 로그인 등의 인증 관련 API")
 public class AuthController {
     private final AuthService authService;
+    private final AuthMapper authMapper;
 
     @Operation(summary = "회원가입", description = "회원 정보를 받아 회원가입을 수행합니다.")
     @PostMapping("/signup")
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
-        var result = authService.signUp(request.toCommand());
-        return ResponseEntity.ok(SignUpResponse.of(result));
+        var result = authService.signUp(authMapper.toSignUpCommand(request));
+        return ResponseEntity.ok(authMapper.toSignUpResponse(result));
     }
 
     @Operation(summary = "로그인", description = "회원 정보를 받아 로그인을 수행합니다.")
@@ -41,7 +43,7 @@ public class AuthController {
     })
     @PostMapping("/login")
     public ResponseEntity<Void> login(@Valid @RequestBody SignInRequest request, HttpServletResponse response) {
-        authService.login(request.toCommand(), response);
+        authService.login(authMapper.toSignInCommand(request), response);
         return ResponseEntity.ok().build();
     }
 
@@ -55,7 +57,8 @@ public class AuthController {
         @CookieValue(name = REFRESH_TOKEN, required = false) String refreshToken,
         HttpServletResponse response
     ) {
-        authService.refresh(new RefreshCommand(accessToken, refreshToken), response);
+        RefreshCommand command = authMapper.toRefreshCommand(accessToken, refreshToken);
+        authService.refresh(command, response);
         return ResponseEntity.ok().build();
     }
 
@@ -71,7 +74,8 @@ public class AuthController {
         @CookieValue(name = REFRESH_TOKEN, required = false) String refreshToken,
         HttpServletResponse response
     ) {
-        authService.logout(new LogoutCommand(accessToken, refreshToken), response);
+        LogoutCommand command = authMapper.toLogoutCommand(accessToken, refreshToken);
+        authService.logout(command, response);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/eventitta/auth/controller/request/SignInRequest.java
+++ b/src/main/java/com/eventitta/auth/controller/request/SignInRequest.java
@@ -1,6 +1,4 @@
 package com.eventitta.auth.controller.request;
-
-import com.eventitta.auth.service.dto.SignInCommand;
 import com.eventitta.common.constants.RegexPattern;
 import com.eventitta.common.constants.ValidationMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,7 +16,4 @@ public record SignInRequest(
     @Pattern(regexp = RegexPattern.PASSWORD, message = ValidationMessage.PASSWORD)
     String password
 ) {
-    public SignInCommand toCommand() {
-        return new SignInCommand(email, password);
-    }
 }

--- a/src/main/java/com/eventitta/auth/controller/request/SignUpRequest.java
+++ b/src/main/java/com/eventitta/auth/controller/request/SignUpRequest.java
@@ -1,6 +1,4 @@
 package com.eventitta.auth.controller.request;
-
-import com.eventitta.auth.service.dto.SignUpCommand;
 import com.eventitta.common.constants.RegexPattern;
 import com.eventitta.common.constants.ValidationMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,9 +21,5 @@ public record SignUpRequest(
     @NotBlank(message = ValidationMessage.NICKNAME)
     @Pattern(regexp = RegexPattern.NICKNAME, message = ValidationMessage.NICKNAME)
     String nickname
-
 ) {
-    public SignUpCommand toCommand() {
-        return new SignUpCommand(email, password, nickname);
-    }
 }

--- a/src/main/java/com/eventitta/auth/controller/response/SignUpResponse.java
+++ b/src/main/java/com/eventitta/auth/controller/response/SignUpResponse.java
@@ -1,6 +1,4 @@
 package com.eventitta.auth.controller.response;
-
-import com.eventitta.auth.service.dto.SignUpResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원가입 응답")
@@ -10,10 +8,4 @@ public record SignUpResponse(
     @Schema(description = "닉네임", example = "johndoe")
     String nickname
 ) {
-    public static SignUpResponse of(SignUpResult result) {
-        return new SignUpResponse(
-            result.email(),
-            result.nickname()
-        );
-    }
 }

--- a/src/main/java/com/eventitta/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/eventitta/auth/mapper/AuthMapper.java
@@ -1,0 +1,37 @@
+package com.eventitta.auth.mapper;
+
+import com.eventitta.auth.controller.request.SignInRequest;
+import com.eventitta.auth.controller.request.SignUpRequest;
+import com.eventitta.auth.controller.response.SignUpResponse;
+import com.eventitta.auth.service.dto.LogoutCommand;
+import com.eventitta.auth.service.dto.RefreshCommand;
+import com.eventitta.auth.service.dto.SignInCommand;
+import com.eventitta.auth.service.dto.SignUpCommand;
+import com.eventitta.auth.service.dto.SignUpResult;
+import com.eventitta.auth.service.dto.TokenResult;
+import com.eventitta.user.domain.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AuthMapper {
+
+    SignUpCommand toSignUpCommand(SignUpRequest request);
+
+    SignInCommand toSignInCommand(SignInRequest request);
+
+    SignUpResult toSignUpResult(User user);
+
+    SignUpResponse toSignUpResponse(SignUpResult result);
+
+    default RefreshCommand toRefreshCommand(String accessToken, String refreshToken) {
+        return new RefreshCommand(accessToken, refreshToken);
+    }
+
+    default LogoutCommand toLogoutCommand(String accessToken, String refreshToken) {
+        return new LogoutCommand(accessToken, refreshToken);
+    }
+
+    default TokenResult toTokenResult(String accessToken, String refreshToken) {
+        return new TokenResult(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/eventitta/auth/service/AuthService.java
+++ b/src/main/java/com/eventitta/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.eventitta.auth.service;
 
 import com.eventitta.auth.exception.AuthException;
+import com.eventitta.auth.mapper.AuthMapper;
 import com.eventitta.auth.service.dto.*;
 import com.eventitta.user.domain.User;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +24,7 @@ public class AuthService {
     private final TokenService tokenService;
     private final RefreshTokenService refreshService;
     private final CookieManager cookieManager;
+    private final AuthMapper authMapper;
 
     public SignUpResult signUp(SignUpCommand signUpCommand) {
         log.info("[회원가입 시작] email={}, nickname={}", signUpCommand.email(), signUpCommand.nickname());
@@ -30,7 +32,7 @@ public class AuthService {
         User user = signUpService.register(signUpCommand);
 
         log.info("[회원가입 완료] userId={}, email={}", user.getId(), user.getEmail());
-        return SignUpResult.of(user);
+        return authMapper.toSignUpResult(user);
     }
 
     public void login(SignInCommand command, HttpServletResponse response) {

--- a/src/main/java/com/eventitta/auth/service/TokenService.java
+++ b/src/main/java/com/eventitta/auth/service/TokenService.java
@@ -2,6 +2,7 @@ package com.eventitta.auth.service;
 
 import com.eventitta.auth.domain.RefreshToken;
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.mapper.AuthMapper;
 import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.auth.service.dto.TokenResult;
 import com.eventitta.user.domain.User;
@@ -26,6 +27,7 @@ public class TokenService {
     private final Pbkdf2PasswordEncoder pbkdf2PasswordEncoder;
     private final UserRepository userRepository;
     private final Clock clock;
+    private final AuthMapper authMapper;
 
     public TokenResult issueTokens(Long userId) {
         User user = userRepository.findById(userId)
@@ -34,7 +36,7 @@ public class TokenService {
         String at = tokenProvider.createAccessToken(userId, user.getEmail(), user.getRole().name());
         String rt = tokenProvider.createRefreshToken();
         persistRefreshToken(user, rt);
-        return new TokenResult(at, rt);
+        return authMapper.toTokenResult(at, rt);
     }
 
     private void persistRefreshToken(User user, String rawRt) {

--- a/src/main/java/com/eventitta/auth/service/dto/SignUpResult.java
+++ b/src/main/java/com/eventitta/auth/service/dto/SignUpResult.java
@@ -1,15 +1,7 @@
 package com.eventitta.auth.service.dto;
 
-import com.eventitta.user.domain.User;
-
 public record SignUpResult(
     String email,
     String nickname
 ) {
-    public static SignUpResult of(User user) {
-        return new SignUpResult(
-            user.getEmail(),
-            user.getNickname()
-        );
-    }
 }

--- a/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/eventitta/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.eventitta.auth.controller;
 
 import com.eventitta.auth.controller.request.SignInRequest;
 import com.eventitta.auth.controller.request.SignUpRequest;
+import com.eventitta.auth.mapper.AuthMapperImpl;
 import com.eventitta.auth.jwt.service.UserInfoService;
 import com.eventitta.auth.service.AuthService;
 import com.eventitta.auth.service.dto.LogoutCommand;
@@ -24,6 +25,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.eventitta.auth.constants.AuthConstants.ACCESS_TOKEN;
@@ -40,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(AuthMapperImpl.class)
 class AuthControllerTest {
 
     @Autowired
@@ -72,9 +75,10 @@ class AuthControllerTest {
             String nickname = "test123";
             String password = "password1234!@@";
             SignUpRequest signupReq = new SignUpRequest(email, password, nickname);
+            SignUpCommand signUpCommand = new SignUpCommand(email, password, nickname);
 
             SignUpResult signUpResult = new SignUpResult(email, nickname);
-            given(authService.signUp(signupReq.toCommand())).willReturn(signUpResult);
+            given(authService.signUp(signUpCommand)).willReturn(signUpResult);
 
             // when
             var result = mockMvc.perform(
@@ -95,7 +99,7 @@ class AuthControllerTest {
         void signUp_fail_when_duplicate_resource_detected_at_database() throws Exception {
             // given
             SignUpRequest signupReq = new SignUpRequest("test@gmail.com", "password1234!@@", "test123");
-            given(authService.signUp(signupReq.toCommand()))
+            given(authService.signUp(new SignUpCommand("test@gmail.com", "password1234!@@", "test123")))
                 .willThrow(CONFLICTED_EMAIL.defaultException());
 
             // when & then
@@ -115,7 +119,7 @@ class AuthControllerTest {
             // given
             SignUpRequest signupReq = new SignUpRequest("test@gmail.com", "password1234!@@", "test123");
             given(userInfoService.getCurrentUserInfo()).willThrow(new IllegalStateException("user-info-failed"));
-            given(authService.signUp(signupReq.toCommand()))
+            given(authService.signUp(new SignUpCommand("test@gmail.com", "password1234!@@", "test123")))
                 .willThrow(new DataIntegrityViolationException("duplicate key"));
 
             // when & then
@@ -252,7 +256,7 @@ class AuthControllerTest {
         void login_success() throws Exception {
             // given
             SignInRequest request = new SignInRequest("test@gmail.com", "password1234!@@");
-            SignInCommand command = request.toCommand();
+            SignInCommand command = new SignInCommand("test@gmail.com", "password1234!@@");
             willAnswer(invocation -> {
                 HttpServletResponse response = invocation.getArgument(1);
                 response.addHeader(HttpHeaders.SET_COOKIE, tokenCookie(ACCESS_TOKEN, "access-token"));

--- a/src/test/java/com/eventitta/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/AuthServiceTest.java
@@ -1,6 +1,8 @@
 package com.eventitta.auth.service;
 
 import com.eventitta.auth.exception.AuthException;
+import com.eventitta.auth.mapper.AuthMapper;
+import com.eventitta.auth.mapper.AuthMapperImpl;
 import com.eventitta.auth.service.dto.*;
 import com.eventitta.user.domain.User;
 import com.eventitta.user.exception.UserException;
@@ -14,6 +16,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.stream.Stream;
@@ -44,6 +47,8 @@ class AuthServiceTest {
     private HttpServletResponse response;
     @Mock
     private CookieManager cookieManager;
+    @Spy
+    private AuthMapper authMapper = new AuthMapperImpl();
 
     @Nested
     @DisplayName("회원가입")

--- a/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/eventitta/auth/service/TokenServiceTest.java
@@ -2,6 +2,8 @@ package com.eventitta.auth.service;
 
 import com.eventitta.auth.domain.RefreshToken;
 import com.eventitta.auth.jwt.JwtTokenProvider;
+import com.eventitta.auth.mapper.AuthMapper;
+import com.eventitta.auth.mapper.AuthMapperImpl;
 import com.eventitta.auth.repository.RefreshTokenRepository;
 import com.eventitta.auth.service.dto.TokenResult;
 import com.eventitta.user.domain.User;
@@ -14,6 +16,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -44,6 +47,8 @@ class TokenServiceTest {
     private UserRepository userRepository;
     @Mock
     private Clock clock;
+    @Spy
+    private AuthMapper authMapper = new AuthMapperImpl();
 
     @Captor
     private ArgumentCaptor<RefreshToken> refreshTokenCaptor;


### PR DESCRIPTION

## 요약

인증 모듈 내 수동 DTO 매핑 로직을 MapStruct 기반의 `AuthMapper`로 전환하여 코드 중복을 제거하고 유지보수성을 향상함.

## 주요 변경사항

**동적으로 바뀔 변경사항**

* MapStruct를 이용한 `AuthMapper` 인터페이스를 도입하여 컨트롤러 요청, 서비스 커맨드/결과, 응답 간의 변환 로직을 자동화함
* 기존 각 DTO 클래스에 흩어져 있던 수동 변환 메서드(`toCommand`, `toResponse` 등)를 전면 삭제
* `AuthController`, `AuthService`, `TokenService`에서 직접 객체를 생성하던 로직을 `AuthMapper` 주입 및 호출 방식으로 변경
* `DTO_GUIDELINES.md` 및 `ARCHITECTURE.md`에 MapStruct 사용 원칙과 매퍼 패키지의 역할을 명시하도록 업데이트
* 테스트 코드(`AuthControllerTest`)에서 `AuthMapperImpl`을 사용하여 실제 매핑 로직이 반영되도록 수정

## 주요 효과

* 반복적인 매핑 코드를 제거하여 보일러플레이트 코드를 획기적으로 줄이고 비즈니스 로직에 집중할 수 있는 환경 구축
* 객체 간 변환 규칙을 `AuthMapper` 한 곳으로 중앙 집중화하여 매핑 정책 변경 시 수정 범위를 최소화함
* 컴파일 타임에 매핑 오류를 잡을 수 있어 런타임 에러 가능성을 낮추고 코드의 안정성을 강화함
