### PR TITLE
Add modular monolith foundation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,127 +1,85 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.4.5'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.4.5' apply false
+    id 'io.spring.dependency-management' version '1.1.7' apply false
     id 'org.ec4j.editorconfig' version '0.1.0'
-    id 'me.champeau.jmh' version '0.7.2'
-    id 'org.flywaydb.flyway' version '10.7.1'
 }
 
-group = 'com'
-version = '0.0.1-SNAPSHOT'
+ext {
+    querydslVersion = '5.0.0'
+    mapstructVersion = '1.5.5.Final'
+}
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+allprojects {
+    group = 'com'
+    version = '0.0.1-SNAPSHOT'
+
+    repositories {
+        mavenCentral()
     }
 }
 
-def querydslVersion = '5.0.0'
+subprojects {
+    apply plugin: 'java-library'
+    apply plugin: 'io.spring.dependency-management'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
     }
-}
 
-repositories {
-    mavenCentral()
-}
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    dependencyManagement {
+        imports {
+            mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        }
+    }
 
-    // Annotation Processors
-    annotationProcessor 'org.projectlombok:lombok'
-    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
-    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    dependencies {
+        compileOnly 'org.projectlombok:lombok:1.18.32'
+        annotationProcessor 'org.projectlombok:lombok:1.18.32'
+        testCompileOnly 'org.projectlombok:lombok:1.18.32'
+        testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'
+        annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+        annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+        annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 
-    // Libraries
-    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
-    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.6.0'
-    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.6.0'
-    implementation 'org.springframework.retry:spring-retry'
-    implementation 'org.springframework:spring-aspects'
-    runtimeOnly 'p6spy:p6spy:3.9.1'
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'org.springframework.security:spring-security-test'
+        testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+        testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+        testImplementation 'org.testcontainers:testcontainers:1.19.3'
+        testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+        testImplementation 'com.redis:testcontainers-redis:2.2.2'
+        testImplementation 'org.awaitility:awaitility:4.2.0'
+        testImplementation 'com.h2database:h2'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
 
-    // xml 파싱 - 단일 객체 파싱 이슈
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    tasks.withType(JavaCompile).configureEach {
+        options.generatedSourceOutputDirectory = file("${layout.buildDirectory.get()}/generated/sources/annotationProcessor/java/main")
+        options.compilerArgs += ['-parameters']
+        options.incremental = false
+    }
 
-    // Flyway 의존성
-    implementation 'org.flywaydb:flyway-core'
-    implementation 'org.flywaydb:flyway-mysql'
-
-    // AWS S3 의존성 추가 (Spring Boot 3.x 호환)
-    implementation 'software.amazon.awssdk:s3:2.20.26'
-    implementation 'software.amazon.awssdk:auth:2.20.26'
-
-    // Spring Actuator
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-    // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'io.lettuce:lettuce-core'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'com.h2database:h2'
-    testImplementation 'org.springframework.security:spring-security-test'
-
-    // Spring Boot Testcontainers Support
-    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-
-    // Testcontainers for Redis
-    testImplementation 'org.testcontainers:testcontainers:1.19.3'
-    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
-    testImplementation 'com.redis:testcontainers-redis:2.2.2'
-
-    // Awaitility for async testing
-    testImplementation 'org.awaitility:awaitility:4.2.0'
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.generatedSourceOutputDirectory = file("${layout.buildDirectory.get()}/generated/sources/annotationProcessor/java/main")
-    options.compilerArgs += ['-parameters']
-    options.incremental = false
+    tasks.withType(Test).configureEach {
+        useJUnitPlatform()
+    }
 }
 
 editorconfig {
-    includes = ['src/**', 'build.gradle']
-    excludes = [
-        '**/generated/**',
-        "${layout.buildDirectory.get()}/**"
+    includes = [
+        'eventitta-app/**',
+        'eventitta-api/**',
+        'eventitta-domain/**',
+        'eventitta-infra/**',
+        'build.gradle',
+        'settings.gradle'
     ]
-}
-
-tasks.named('check') {
-    dependsOn 'editorconfigCheck'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-}
-
-// JMH 설정
-jmh {
-    iterations = 5
-    warmupIterations = 5
-    fork = 2
-    benchmarkMode = ['avgt'] // Average time
-    timeUnit = 'us' // microseconds
-    includes = ['.*Benchmark.*']
+    excludes = ['**/generated/**', '**/build/**']
 }

--- a/eventitta-api/build.gradle
+++ b/eventitta-api/build.gradle
@@ -1,0 +1,15 @@
+dependencies {
+    implementation project(':eventitta-domain')
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework:spring-tx'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation "org.mapstruct:mapstruct:${rootProject.ext.mapstructVersion}"
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+}

--- a/eventitta-app/build.gradle
+++ b/eventitta-app/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'org.springframework.boot'
+
+dependencies {
+    implementation project(':eventitta-api')
+    implementation project(':eventitta-domain')
+    implementation project(':eventitta-infra')
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'p6spy:p6spy:3.9.1'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    testImplementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    testImplementation 'software.amazon.awssdk:s3:2.20.26'
+    testImplementation 'net.javacrumbs.shedlock:shedlock-spring:6.6.0'
+}
+
+tasks.named('jar') {
+    enabled = false
+}

--- a/eventitta-app/src/main/java/com/eventitta/app/EventittaApplication.java
+++ b/eventitta-app/src/main/java/com/eventitta/app/EventittaApplication.java
@@ -1,0 +1,17 @@
+package com.eventitta.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = "com.eventitta")
+@EntityScan(basePackages = "com.eventitta.domain")
+@EnableJpaRepositories(basePackages = {"com.eventitta.domain", "com.eventitta.infra"})
+public class EventittaApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EventittaApplication.class, args);
+    }
+
+}

--- a/eventitta-app/src/main/java/com/eventitta/app/auth/config/AuthPropertiesConfig.java
+++ b/eventitta-app/src/main/java/com/eventitta/app/auth/config/AuthPropertiesConfig.java
@@ -1,0 +1,23 @@
+package com.eventitta.app.auth.config;
+
+import com.eventitta.domain.auth.config.AuthActionTokenProperties;
+import com.eventitta.domain.auth.config.AuthRateLimitProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuthPropertiesConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "auth.action-token")
+    public AuthActionTokenProperties authActionTokenProperties() {
+        return new AuthActionTokenProperties();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "auth.rate-limit")
+    public AuthRateLimitProperties authRateLimitProperties() {
+        return new AuthRateLimitProperties();
+    }
+}

--- a/eventitta-app/src/main/resources/application-docker.yml
+++ b/eventitta-app/src/main/resources/application-docker.yml
@@ -1,0 +1,112 @@
+spring:
+  datasource:
+    url: jdbc:mysql://db:${DB_PORT:3306}/eventitta?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none  # Flyway로 스키마 관리
+    defer-datasource-initialization: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: never
+
+  # Flyway 설정 추가
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
+    clean-disabled: false  # Docker 환경에서는 clean 허용
+
+  devtools:
+    restart:
+      enabled: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 60MB
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+    with-credentials: true
+    persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Docker container server
+
+file:
+  storage:
+    location: ./uploads
+festival:
+  seoul:
+    base-url: http://openapi.seoul.go.kr:8088
+  national:
+    base-url: http://api.data.go.kr/openapi/tn_pubr_public_cltur_fstvl_api
+  geocoding:
+    enabled: true
+
+api:
+  seoul:
+    key: ${SEOUL_API_KEY:your-seoul-api-key-here}
+  national:
+    key: ${NATIONAL_API_KEY:your-national-api-key-here}
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: WARN
+    p6spy: DEBUG
+async:
+  core-pool-size: 4
+  max-pool-size: 20
+  queue-capacity: 200
+
+jwt:
+  secret: ${SECRET_KEY}
+  access-token-validity-ms: 3600000        # 1시간
+  refresh-token-validity-ms: 86400000      # 24시간
+
+auth:
+  social:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:test-kakao-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:test-kakao-client-secret}
+      authorize-base-url: https://kauth.kakao.com/oauth/authorize
+      token-base-url: https://kauth.kakao.com
+      api-base-url: https://kapi.kakao.com
+      state-cookie-max-age-seconds: 300
+      allowed-redirect-uris:
+        - http://localhost:3000/auth/kakao/callback
+        - http://127.0.0.1:3000/auth/kakao/callback
+        - http://localhost:5173/auth/kakao/callback
+        - http://127.0.0.1:5173/auth/kakao/callback
+
+security:
+  cors:
+    allowed-origins:
+      - http://localhost:3000
+      - http://127.0.0.1:3000
+      - http://localhost:5173
+      - http://127.0.0.1:5173
+
+notification:
+  slack:
+    enabled: true
+
+server:
+  port: 8080

--- a/eventitta-app/src/main/resources/application-local.yml
+++ b/eventitta-app/src/main/resources/application-local.yml
@@ -1,0 +1,157 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:p6spy:mysql://localhost:${DB_PORT:3306}/eventitta?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: eventittaUser
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.p6spy.engine.spy.P6SpyDriver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    defer-datasource-initialization: false
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
+  sql:
+    init:
+      mode: never
+      data-locations: classpath:data.sql
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
+    clean-disabled: false
+  devtools:
+    restart:
+      enabled: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 60MB
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 10
+          min-idle: 2
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+    with-credentials: true
+    persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Local development server
+
+jwt:
+  secret: ${SECRET_KEY}
+  access-token-validity-ms: 3600000
+  refresh-token-validity-ms: 86400000
+
+auth:
+  social:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:test-kakao-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:test-kakao-client-secret}
+      authorize-base-url: https://kauth.kakao.com/oauth/authorize
+      token-base-url: https://kauth.kakao.com
+      api-base-url: https://kapi.kakao.com
+      state-cookie-max-age-seconds: 300
+      allowed-redirect-uris:
+        - http://localhost:3000/auth/kakao/callback
+        - http://127.0.0.1:3000/auth/kakao/callback
+        - http://localhost:5173/auth/kakao/callback
+        - http://127.0.0.1:5173/auth/kakao/callback
+
+security:
+  cors:
+    allowed-origins:
+      - http://localhost:3000
+      - http://127.0.0.1:3000
+      - http://localhost:5173
+      - http://127.0.0.1:5173
+
+file:
+  storage:
+    location: ./uploads
+
+festival:
+  seoul:
+    base-url: http://openapi.seoul.go.kr:8088
+  national:
+    base-url: http://api.data.go.kr/openapi/tn_pubr_public_cltur_fstvl_api
+  geocoding:
+    enabled: true
+
+api:
+  seoul:
+    key: ${SEOUL_API_KEY:your-seoul-api-key-here}
+  national:
+    key: ${NATIONAL_API_KEY:your-national-api-key-here}
+
+logging:
+  level:
+    root: INFO
+    com.eventitta: DEBUG                    # 애플리케이션 전체 상세 로그
+    com.eventitta.festivals: DEBUG          # 축제 도메인 디버깅
+    com.eventitta.platform.interceptor: DEBUG # RestClient 요청/응답 상세
+    org.springframework.web: INFO
+    org.springframework.security: INFO
+    org.hibernate.SQL: DEBUG                # SQL 쿼리 확인
+    p6spy: INFO                             # 쿼리 파라미터 바인딩 확인
+  file: # 로컬에서도 파일 로깅 활성화 (테스트용)
+    path: ./logs
+    name: ./logs/eventitta.log
+
+async:
+  core-pool-size: 4
+  max-pool-size: 20
+  queue-capacity: 200
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,loggers,metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+    loggers:
+      enabled: true
+
+monitoring:
+  log:
+    enabled: true
+    error-threshold: 3
+    time-window-minutes: 2
+    size-threshold-mb: 10
+    alert-cooldown-minutes: 30
+
+notification:
+  discord:
+    enabled: false

--- a/eventitta-app/src/main/resources/application-perf.yml
+++ b/eventitta-app/src/main/resources/application-perf.yml
@@ -1,0 +1,187 @@
+spring:
+  config:
+    activate:
+      on-profile: perf
+  datasource:
+    url: jdbc:mysql://${PERF_DB_HOST:db}:${PERF_DB_PORT:3306}/${DB_NAME:eventitta_perf}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${JDBC_USERNAME:eventittaUser}
+    password: ${JDBC_PASSWORD:eventittaPass}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+  sql:
+    init:
+      mode: never
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
+    out-of-order: false
+    clean-disabled: true
+    url: ${spring.datasource.url}
+    user: ${spring.datasource.username}
+    password: ${spring.datasource.password}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 60MB
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+  data:
+    redis:
+      host: ${PERF_REDIS_HOST:redis}
+      port: ${PERF_REDIS_PORT:6379}
+      ssl:
+        enabled: false
+      timeout: 2000ms
+      connect-timeout: 5000ms
+      command-timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 5
+          min-idle: 2
+          max-wait: 2000ms
+          time-between-eviction-runs: 60s
+        read-from: MASTER
+        cluster:
+          refresh:
+            adaptive: false
+            period: 300s
+          follow-redirects: false
+          max-redirects: 0
+
+server:
+  port: 8080
+  forward-headers-strategy: framework
+  tomcat:
+    remoteip:
+      protocol-header: X-Forwarded-Proto
+      remote-ip-header: X-Forwarded-For
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+    with-credentials: true
+    persist-authorization: true
+  server:
+    url: http://localhost:${PERF_NGINX_PORT:18080}
+    description: Perf validation server
+
+jwt:
+  secret: ${JWT_SECRET:perf-jwt-secret-change-me-32-byte-minimum}
+  access-token-validity-ms: ${JWT_ACCESS_TOKEN_VALIDITY:3600000}
+  refresh-token-validity-ms: ${JWT_REFRESH_TOKEN_VALIDITY:86400000}
+
+cookie:
+  secure: false
+
+auth:
+  social:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:perf-kakao-client-id}
+      client-secret: ${KAKAO_CLIENT_SECRET:perf-kakao-client-secret}
+      authorize-base-url: ${PERF_KAKAO_AUTHORIZE_BASE_URL:http://mock-services:8080/kakao/authorize}
+      token-base-url: ${PERF_KAKAO_TOKEN_BASE_URL:http://mock-services:8080/kakao}
+      api-base-url: ${PERF_KAKAO_API_BASE_URL:http://mock-services:8080/kakao}
+      state-cookie-max-age-seconds: ${KAKAO_STATE_COOKIE_MAX_AGE_SECONDS:300}
+      allowed-redirect-uris:
+        - http://localhost:${PERF_NGINX_PORT:18080}/auth/kakao/callback
+        - http://127.0.0.1:${PERF_NGINX_PORT:18080}/auth/kakao/callback
+
+security:
+  cors:
+    allowed-origins:
+      - http://localhost:${PERF_NGINX_PORT:18080}
+      - http://127.0.0.1:${PERF_NGINX_PORT:18080}
+
+file:
+  storage:
+    location: /app/uploads
+
+festival:
+  seoul:
+    base-url: ${PERF_SEOUL_BASE_URL:http://mock-services:8080/seoul}
+  national:
+    base-url: ${PERF_NATIONAL_BASE_URL:http://mock-services:8080/national}
+  geocoding:
+    base-url: ${PERF_GEOCODING_BASE_URL:http://mock-services:8080/geocoding}
+    enabled: true
+    timeout-seconds: 10
+    request-delay-ms: ${PERF_GEOCODING_REQUEST_DELAY_MS:0}
+
+api:
+  seoul:
+    key: ${SEOUL_API_KEY:perf-seoul-key}
+  national:
+    key: ${NATIONAL_API_KEY:perf-national-key}
+
+logging:
+  level:
+    root: INFO
+    com.eventitta: INFO
+    com.eventitta.festivals.scheduler: INFO
+    com.eventitta.festivals.service.geocoding: INFO
+    com.eventitta.platform.interceptor: INFO
+    org.springframework: WARN
+    org.springframework.web: WARN
+    org.springframework.security: WARN
+    org.hibernate: WARN
+    org.hibernate.SQL: WARN
+    p6spy: OFF
+    com.zaxxer.hikari: INFO
+
+async:
+  core-pool-size: 4
+  max-pool-size: 20
+  queue-capacity: 200
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,loggers,metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+    loggers:
+      enabled: true
+  security:
+    enabled: false
+
+notification:
+  discord:
+    enabled: false
+
+monitoring:
+  log:
+    enabled: true
+    error-threshold: 20
+    time-window-minutes: 5
+    size-threshold-mb: 900
+    alert-cooldown-minutes: 30
+
+media:
+  delivery:
+    cdn-base-url: ${MEDIA_CDN_BASE_URL:http://localhost:${PERF_NGINX_PORT:18080}}
+
+scheduler:
+  image-cleanup:
+    enabled: false

--- a/eventitta-app/src/main/resources/application-prod.yml
+++ b/eventitta-app/src/main/resources/application-prod.yml
@@ -1,0 +1,195 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:mysql://${RDS_ENDPOINT}:3306/${DB_NAME}?useSSL=true&requireSSL=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${JDBC_USERNAME}
+    password: ${JDBC_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+  sql:
+    init:
+      mode: never
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
+    out-of-order: false
+    clean-disabled: true
+    url: ${spring.datasource.url}
+    user: ${spring.datasource.username}
+    password: ${spring.datasource.password}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 60MB
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+  data:
+    redis:
+      host: ${ELASTICACHE_PRIMARY_ENDPOINT}
+      port: 6379
+      ssl:
+        enabled: true
+      password: ${ELASTICACHE_AUTH_TOKEN:}
+      timeout: 2000ms
+      connect-timeout: 5000ms
+      command-timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 10
+          max-idle: 5
+          min-idle: 2
+          max-wait: 2000ms
+          time-between-eviction-runs: 60s
+        read-from: MASTER
+        cluster:
+          refresh:
+            adaptive: false
+            period: 300s
+          follow-redirects: false
+          max-redirects: 0
+
+server:
+  port: ${SERVER_PORT:8080}
+  forward-headers-strategy: framework
+  tomcat:
+    remoteip:
+      protocol-header: X-Forwarded-Proto
+      remote-ip-header: X-Forwarded-For
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+  server:
+    url: https://eventitta.com
+    description: Production server
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity-ms: ${JWT_ACCESS_TOKEN_VALIDITY:3600000}
+  refresh-token-validity-ms: ${JWT_REFRESH_TOKEN_VALIDITY:86400000}
+
+cookie:
+  secure: true
+
+auth:
+  social:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID}
+      client-secret: ${KAKAO_CLIENT_SECRET}
+      authorize-base-url: https://kauth.kakao.com/oauth/authorize
+      token-base-url: https://kauth.kakao.com
+      api-base-url: https://kapi.kakao.com
+      state-cookie-max-age-seconds: ${KAKAO_STATE_COOKIE_MAX_AGE_SECONDS:300}
+      allowed-redirect-uris:
+        - ${KAKAO_ALLOWED_REDIRECT_URI:https://eventitta.com/auth/kakao/callback}
+
+security:
+  cors:
+    allowed-origins:
+      - ${APP_ALLOWED_ORIGIN:https://eventitta.com}
+
+file:
+  storage:
+    location: ${FILE_STORAGE_LOCATION:/app/uploads}
+
+festival:
+  seoul:
+    base-url: http://openapi.seoul.go.kr:8088
+  national:
+    base-url: http://api.data.go.kr/openapi/tn_pubr_public_cltur_fstvl_api
+  geocoding:
+    enabled: true
+    timeout-seconds: 10
+
+api:
+  seoul:
+    key: ${SEOUL_API_KEY}
+  national:
+    key: ${NATIONAL_API_KEY}
+
+cloud:
+  aws:
+    region:
+      static: ${AWS_REGION:ap-northeast-2}
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    stack:
+      auto: false
+
+logging:
+  level:
+    root: WARN
+    com.eventitta: INFO
+    com.eventitta.festivals.scheduler: WARN
+    com.eventitta.festivals.service.geocoding: WARN
+    com.eventitta.platform.interceptor: WARN
+    org.springframework: ERROR
+    org.springframework.web: ERROR
+    org.springframework.security: ERROR
+    org.hibernate: ERROR
+    org.hibernate.SQL: ERROR
+    p6spy: OFF
+    com.zaxxer.hikari: WARN
+
+async:
+  core-pool-size: 4
+  max-pool-size: 20
+  queue-capacity: 200
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,loggers
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+    loggers:
+      enabled: true
+  security:
+    enabled: false
+
+notification:
+  discord:
+    enabled: true
+    webhook-url: ${DISCORD_WEBHOOK_URL}
+    username: ${DISCORD_USERNAME:eventitta-bot}
+    timeout-seconds: ${DISCORD_TIMEOUT:5}
+
+monitoring:
+  log:
+    enabled: true
+    error-threshold: 20
+    time-window-minutes: 5
+    size-threshold-mb: 900
+    alert-cooldown-minutes: 30
+
+media:
+  delivery:
+    cdn-base-url: ${MEDIA_CDN_BASE_URL:https://cdn.eventitta.com}
+
+scheduler:
+  image-cleanup:
+    enabled: false

--- a/eventitta-app/src/main/resources/application-test.yml
+++ b/eventitta-app/src/main/resources/application-test.yml
@@ -1,0 +1,135 @@
+# yaml
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  flyway:
+    enabled: false
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;NON_KEYWORDS=VALUE,KEY,USER
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        globally_quoted_identifiers: false
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    defer-datasource-initialization: true
+
+  # H2에서 ShedLock 테이블 생성을 위해 활성화
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+      # 테스트에서 src/main/resources/data.sql(프로덕션 시드)가 실행되지 않도록
+      # no-op 스크립트를 지정한다.
+      data-locations: classpath:data-test.sql
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 60MB
+
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+    with-credentials: true
+    persist-authorization: true
+  server:
+    url: http://localhost:8080
+    description: Test server
+
+jwt:
+  secret: eb583f5872f5bde4833167f91002f263fdec66cc9b3be80eb3517692dd8c245b
+  access-token-validity-ms: 3600000
+  refresh-token-validity-ms: 86400000
+
+auth:
+  social:
+    kakao:
+      client-id: test-kakao-client-id
+      client-secret: test-kakao-client-secret
+      authorize-base-url: https://kauth.kakao.com/oauth/authorize
+      token-base-url: https://kauth.kakao.com
+      api-base-url: https://kapi.kakao.com
+      state-cookie-max-age-seconds: 300
+      allowed-redirect-uris:
+        - http://localhost:3000/auth/kakao/callback
+        - http://localhost:5173/auth/kakao/callback
+
+security:
+  cors:
+    allowed-origins:
+      - http://localhost:3000
+      - http://localhost:5173
+
+file:
+  storage:
+    location: ./test-uploads
+
+festival:
+  seoul:
+    base-url: http://openapi.seoul.go.kr:8088
+  national:
+    base-url: https://apis.data.go.kr
+  geocoding:
+    enabled: false
+
+api:
+  seoul:
+    key: ${SEOUL_API_KEY:test-seoul-api-key}
+  national:
+    key: ${NATIONAL_API_KEY:test-national-api-key}
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: INFO
+
+# Scheduling disabled for tests
+scheduling:
+  enabled: false
+
+# 개별 스케줄러 비활성화 (matchIfMissing = true이므로 명시적으로 false 설정 필요)
+scheduler:
+  festival-sync:
+    enabled: false
+  meeting-status:
+    enabled: false
+  token-cleanup:
+    enabled: false
+  image-cleanup:
+    enabled: false
+  gamification-reconciliation:
+    enabled: false
+
+# 테스트 환경에서는 알림 비활성화
+notification:
+  discord:
+    enabled: false

--- a/eventitta-app/src/main/resources/application.yml
+++ b/eventitta-app/src/main/resources/application.yml
@@ -1,0 +1,57 @@
+spring:
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: true
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: false
+  sql:
+    init:
+      mode: never
+      schema-locations: classpath:schema.sql
+  cache:
+    type: caffeine
+
+cache:
+  caffeine:
+    maximum-size: 20
+    ttl-days: 30
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: WARN
+    com.eventitta.festivals: DEBUG
+    com.eventitta.platform.interceptor: DEBUG
+    festival.error: INFO
+
+# Swagger/OpenAPI 서버 설정
+springdoc:
+  server:
+    url: http://localhost:8080
+    description: Development server
+
+# 축제 데이터 처리 관련 설정
+festival:
+  geocoding:
+    base-url: https://nominatim.openstreetmap.org
+    user-agent: Eventitta/1.0 (${GEOCODING_CONTACT_EMAIL:dev@eventitta.com})
+    timeout-seconds: 5
+    request-delay-ms: 1000
+    enabled: true
+
+notification:
+  discord:
+    enabled: false
+    webhook-url: ${DISCORD_WEBHOOK_URL:}
+    username: "eventitta-bot"
+    timeout-seconds: 5
+
+monitoring:
+  log:
+    enabled: false
+
+cookie:
+  secure: false

--- a/eventitta-app/src/main/resources/logback-spring.xml
+++ b/eventitta-app/src/main/resources/logback-spring.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <!-- 속성 정의 -->
+  <property name="LOG_DIR" value="${LOG_PATH:-/app/logs}"/>
+  <property name="LOG_FILE_NAME" value="eventitta"/>
+  <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+  <!-- 콘솔 Appender (local, test 프로파일용) -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <!-- =========================== -->
+  <!-- Production 프로파일 설정 -->
+  <!-- =========================== -->
+  <springProfile name="prod">
+    <!-- 일반 로그 파일 Appender (7일 보관) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/${LOG_FILE_NAME}.log</file>
+      <encoder>
+        <pattern>${LOG_PATTERN}</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <!-- 파일명 패턴: eventitta-2025-10-21.0.log.gz -->
+        <fileNamePattern>${LOG_DIR}/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <!-- 최대 파일 크기 -->
+        <maxFileSize>50MB</maxFileSize>
+        <!-- 보관 기간: 7일 -->
+        <maxHistory>7</maxHistory>
+        <!-- 전체 로그 용량 제한: 700MB (에러 로그 300MB 고려) -->
+        <totalSizeCap>700MB</totalSizeCap>
+        <!-- 시작 시 오래된 로그 정리 -->
+        <cleanHistoryOnStart>true</cleanHistoryOnStart>
+      </rollingPolicy>
+      <!-- TRACE, DEBUG 로그는 파일에 기록하지 않음 -->
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>INFO</level>
+      </filter>
+    </appender>
+
+    <!-- 에러 전용 로그 파일 Appender (30일 보관) -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${LOG_DIR}/error.log</file>
+      <encoder>
+        <pattern>${LOG_PATTERN}</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_DIR}/error-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>30MB</maxFileSize>
+        <!-- 에러 로그는 30일 보관 (장애 추적용) -->
+        <maxHistory>30</maxHistory>
+        <!-- 에러 로그 용량 제한: 300MB -->
+        <totalSizeCap>300MB</totalSizeCap>
+        <cleanHistoryOnStart>true</cleanHistoryOnStart>
+      </rollingPolicy>
+      <!-- ERROR 레벨만 기록 -->
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+    </appender>
+
+    <!-- Async Appender로 I/O 성능 최적화 -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+      <!-- 큐 크기: 메모리 1GB 환경 고려하여 256으로 제한 -->
+      <queueSize>256</queueSize>
+      <!-- 큐의 여유 공간이 51(20%) 이하일 때 TRACE, DEBUG 로그 버림 -->
+      <discardingThreshold>51</discardingThreshold>
+      <!-- false: 큐가 가득 차면 로그 작성 대기 (로그 손실 방지) -->
+      <neverBlock>false</neverBlock>
+      <!-- 최대 flush 시간: 애플리케이션 종료 시 로그 손실 방지 -->
+      <maxFlushTime>5000</maxFlushTime>
+      <appender-ref ref="FILE"/>
+    </appender>
+
+    <appender name="ASYNC_ERROR_FILE" class="ch.qos.logback.classic.AsyncAppender">
+      <queueSize>128</queueSize>
+      <!-- 에러 로그는 절대 버리지 않음 -->
+      <discardingThreshold>0</discardingThreshold>
+      <neverBlock>false</neverBlock>
+      <maxFlushTime>5000</maxFlushTime>
+      <appender-ref ref="ERROR_FILE"/>
+    </appender>
+
+    <!-- 애플리케이션 로거 -->
+    <logger name="com.eventitta" level="INFO" additivity="false">
+      <appender-ref ref="ASYNC_FILE"/>
+      <appender-ref ref="ASYNC_ERROR_FILE"/>
+    </logger>
+
+    <!-- 축제 스케줄러: WARN만 기록 (동기화 시 대량 로그 방지) -->
+    <logger name="com.eventitta.festivals.scheduler" level="WARN" additivity="false">
+      <appender-ref ref="ASYNC_FILE"/>
+      <appender-ref ref="ASYNC_ERROR_FILE"/>
+    </logger>
+
+    <!-- Spring Framework: ERROR만 -->
+    <logger name="org.springframework" level="ERROR"/>
+    <logger name="org.springframework.web" level="ERROR"/>
+    <logger name="org.springframework.security" level="ERROR"/>
+
+    <!-- Hibernate: ERROR만 -->
+    <logger name="org.hibernate" level="ERROR"/>
+    <logger name="org.hibernate.SQL" level="ERROR"/>
+
+    <!-- P6Spy: 운영 환경에서는 비활성화 -->
+    <logger name="p6spy" level="OFF"/>
+
+    <!-- QueryDSL -->
+    <logger name="com.querydsl" level="ERROR"/>
+
+    <!-- HikariCP: WARN (커넥션 풀 이슈만) -->
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+
+    <!-- Root Logger -->
+    <root level="WARN">
+      <appender-ref ref="ASYNC_FILE"/>
+      <appender-ref ref="ASYNC_ERROR_FILE"/>
+    </root>
+  </springProfile>
+
+  <!-- =========================== -->
+  <!-- Local 프로파일 설정 -->
+  <!-- =========================== -->
+  <springProfile name="local">
+    <!-- 로컬 환경용 파일 Appender -->
+    <appender name="LOCAL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>./logs/${LOG_FILE_NAME}.log</file>
+      <encoder>
+        <pattern>${LOG_PATTERN}</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>./logs/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>10MB</maxFileSize>
+        <maxHistory>3</maxHistory>
+        <totalSizeCap>30MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <!-- 로컬 환경용 에러 파일 Appender -->
+    <appender name="LOCAL_ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>./logs/error.log</file>
+      <encoder>
+        <pattern>${LOG_PATTERN}</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>./logs/error-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>10MB</maxFileSize>
+        <maxHistory>3</maxHistory>
+        <totalSizeCap>30MB</totalSizeCap>
+      </rollingPolicy>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+    </appender>
+
+    <logger name="com.eventitta" level="DEBUG"/>
+    <logger name="com.eventitta.festivals" level="DEBUG"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="p6spy" level="DEBUG"/>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="LOCAL_FILE"/>
+      <appender-ref ref="LOCAL_ERROR_FILE"/>
+    </root>
+  </springProfile>
+
+  <!-- =========================== -->
+  <!-- Test 프로파일 설정 -->
+  <!-- =========================== -->
+  <springProfile name="test">
+    <logger name="com.eventitta" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="p6spy" level="OFF"/>
+
+    <root level="WARN">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <!-- =========================== -->
+  <!-- Docker 프로파일 설정 -->
+  <!-- =========================== -->
+  <springProfile name="docker">
+    <logger name="com.eventitta" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate.SQL" level="WARN"/>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+</configuration>

--- a/eventitta-app/src/main/resources/schema.sql
+++ b/eventitta-app/src/main/resources/schema.sql
@@ -1,0 +1,10 @@
+-- ShedLock 테이블 생성
+CREATE TABLE IF NOT EXISTS shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP    NOT NULL,
+    locked_at  TIMESTAMP    NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);
+

--- a/eventitta-app/src/main/resources/spy.properties
+++ b/eventitta-app/src/main/resources/spy.properties
@@ -1,0 +1,3 @@
+module.log=com.p6spy.engine.spy.appender.Slf4JLogger
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logMessageFormat=com.p6spy.engine.spy.appender.MultiLineFormat

--- a/eventitta-domain/build.gradle
+++ b/eventitta-domain/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.security:spring-security-core'
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    implementation "org.mapstruct:mapstruct:${mapstructVersion}"
+    implementation 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.22'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    implementation 'com.github.usefulness:webp-imageio:0.10.2'
+    implementation 'com.drewnoakes:metadata-extractor:2.19.0'
+}

--- a/eventitta-domain/src/main/java/com/eventitta/domain/auth/config/AuthActionTokenProperties.java
+++ b/eventitta-domain/src/main/java/com/eventitta/domain/auth/config/AuthActionTokenProperties.java
@@ -1,0 +1,11 @@
+package com.eventitta.domain.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthActionTokenProperties {
+    private long emailVerificationTtlSeconds = 86_400L;
+    private long passwordResetTtlSeconds = 1_800L;
+}

--- a/eventitta-domain/src/main/java/com/eventitta/domain/auth/config/AuthRateLimitProperties.java
+++ b/eventitta-domain/src/main/java/com/eventitta/domain/auth/config/AuthRateLimitProperties.java
@@ -1,0 +1,14 @@
+package com.eventitta.domain.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthRateLimitProperties {
+    private int loginMaxFailures = 5;
+    private int socialLoginMaxFailures = 5;
+    private int refreshMaxFailures = 8;
+    private long windowSeconds = 300L;
+    private long lockSeconds = 900L;
+}

--- a/eventitta-infra/build.gradle
+++ b/eventitta-infra/build.gradle
@@ -1,0 +1,22 @@
+dependencies {
+    implementation project(':eventitta-domain')
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework:spring-jdbc'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
+    implementation "com.querydsl:querydsl-jpa:${rootProject.ext.querydslVersion}:jakarta"
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation 'io.lettuce:lettuce-core'
+    implementation 'software.amazon.awssdk:s3:2.20.26'
+    implementation 'software.amazon.awssdk:auth:2.20.26'
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.6.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.6.0'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
 rootProject.name = 'eventitta'
+
+include 'eventitta-app'
+include 'eventitta-api'
+include 'eventitta-domain'
+include 'eventitta-infra'


### PR DESCRIPTION
## 🔍 해결하려는 문제가 무엇인가요?
멀티 모듈 전환을 시작하기 전에, `dev` 브랜치의 단일 Gradle 모듈 구조에서는 이후 경계 분리를 작은 PR 단위로 진행하기 어려웠습니다.

이번 PR은 비즈니스 로직 이동 없이 먼저 모듈 골격과 앱 조립 지점을 세워서, 이후 auth/common/bounded-context 리팩터를 stacked PR로 이어갈 수 있는 기반을 만드는 것이 목적입니다.

## 🛠️ 어떻게 해결했나요?
- Gradle을 멀티 프로젝트 구조로 전환했습니다.
- `eventitta-app`, `eventitta-api`, `eventitta-domain`, `eventitta-infra` 모듈의 기본 build 파일을 추가했습니다.
- Spring Boot 진입점과 런타임 설정 리소스를 `eventitta-app`으로 옮겼습니다.
- `eventitta-app`이 직접 참조하는 최소 domain 설정 클래스만 `eventitta-domain`에 먼저 분리했습니다.
- 대용량 DB migration/data 리소스는 첫 PR 범위에서 제외하고 후속 PR로 넘겼습니다.

## ✨ 주요 변경사항
- `settings.gradle`에 4개 모듈 등록
- 루트 `build.gradle`을 공통 설정용 멀티 프로젝트 구조로 정리
- `eventitta-app` 추가: 부트스트랩 + application/logging 리소스
- `eventitta-domain` 추가: auth properties 최소 표면
- `eventitta-api`, `eventitta-infra` 모듈 build 골격 추가

## ✅ 검증 시나리오
- `./gradlew testClasses`

## 📎 첨부 (Attachment)
- 후속 stacked PR에서 common/auth/user-region/post-comment/meeting-gamification/media-test-docs 순으로 확장 예정입니다.

## 📚 참고 링크
- snapshot branch: `wip/modular-monolith-snapshot-2026-04-10`