### PR TITLE
Stabilize modular test ownership

### DIFF
--- a/eventitta-api/src/test/java/com/eventitta/api/TestApiApplication.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/TestApiApplication.java
@@ -1,0 +1,7 @@
+package com.eventitta.api;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.eventitta.api")
+public class TestApiApplication {
+}

--- a/eventitta-infra/src/test/java/com/eventitta/infra/TestInfraApplication.java
+++ b/eventitta-infra/src/test/java/com/eventitta/infra/TestInfraApplication.java
@@ -1,0 +1,7 @@
+package com.eventitta.infra;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.eventitta.infra")
+public class TestInfraApplication {
+}


### PR DESCRIPTION
## Summary
- add module-local Spring Boot test configuration anchors for `eventitta-api` and `eventitta-infra`
- keep `eventitta-app` limited to the architecture test only, with feature tests now owned by their module packages
- make `./gradlew test` pass on the stacked modular refactor branch set

## Why
After the feature slices moved into separate Gradle modules, several slice tests no longer had a local `@SpringBootConfiguration` to bootstrap from. This PR finishes the test ownership transition by giving the API and infra modules their own test anchors so the modular test suite can run end to end without relying on the old monolith layout.

## Validation
- `./gradlew test`