### PR TITLE
refactor: reorganize api/auth/security into 2-depth subpackages

### DIFF
--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/config/SecurityConfig.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/config/SecurityConfig.java
@@ -1,11 +1,11 @@
-package com.eventitta.api.auth;
+package com.eventitta.api.auth.security.config;
 
 import com.eventitta.api.auth.jwt.JwtTokenProvider;
-import com.eventitta.api.auth.jwt.JwtAccessDeniedHandler;
-import com.eventitta.api.auth.jwt.JwtAuthenticationFilter;
-import com.eventitta.api.auth.jwt.CustomUserDetailsService;
-import com.eventitta.api.auth.jwt.JwtAuthenticationEntryPoint;
-import com.eventitta.api.auth.security.SecurityCorsProperties;
+import com.eventitta.api.auth.security.handler.JwtAccessDeniedHandler;
+import com.eventitta.api.auth.security.filter.JwtAuthenticationFilter;
+import com.eventitta.api.auth.security.userdetails.CustomUserDetailsService;
+import com.eventitta.api.auth.security.handler.JwtAuthenticationEntryPoint;
+import com.eventitta.api.auth.security.config.SecurityCorsProperties;
 import com.eventitta.domain.auth.repository.RefreshTokenRepository;
 import com.eventitta.domain.user.api.internal.facade.UserInternalFacade;
 import lombok.RequiredArgsConstructor;

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/config/SecurityCorsProperties.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/config/SecurityCorsProperties.java
@@ -1,4 +1,4 @@
-package com.eventitta.api.auth.security;
+package com.eventitta.api.auth.security.config;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/credential/AuthenticationManagerCredentialAuthenticator.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/credential/AuthenticationManagerCredentialAuthenticator.java
@@ -1,6 +1,6 @@
-package com.eventitta.api.auth.security;
+package com.eventitta.api.auth.security.credential;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.domain.auth.exception.AuthErrorCode;
 import com.eventitta.domain.auth.port.CredentialAuthenticator;
 import lombok.RequiredArgsConstructor;

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/filter/JwtAuthenticationFilter.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.filter;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.api.auth.jwt.ParsedAccessToken;
 import com.eventitta.api.auth.jwt.JwtTokenProvider;
 import com.eventitta.api.auth.jwt.JwtTokenUtil;

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/handler/JwtAccessDeniedHandler.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/handler/JwtAccessDeniedHandler.java
@@ -1,7 +1,7 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.handler;
 
-import com.eventitta.domain.auth.exception.AuthErrorCode;
 import com.eventitta.api.auth.jwt.UserInfoService;
+import com.eventitta.domain.common.exception.CommonErrorCode;
 import com.eventitta.api.common.response.ApiErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -19,44 +19,40 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
     private final UserInfoService userInfoService;
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
         log.warn(
-            "[Exception] Authentication failure errorCode={}, status={}, path={}, userInfo={}, exceptionType={}, message={}",
-            AuthErrorCode.ACCESS_TOKEN_INVALID.name(),
-            HttpStatus.UNAUTHORIZED.value(),
+            "[Exception] Access denied errorCode={}, status={}, path={}, userInfo={}, exceptionType={}, message={}",
+            CommonErrorCode.FORBIDDEN.name(),
+            HttpStatus.FORBIDDEN.value(),
             request.getRequestURI(),
             resolveUserInfoSafely(request),
-            authException.getClass().getName(),
-            authException.getMessage()
+            accessDeniedException.getClass().getName(),
+            accessDeniedException.getMessage()
         );
         writeErrorResponse(request, response);
     }
 
     private void writeErrorResponse(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        ApiErrorResponse body = createErrorResponseBody(request);
-        setResponseHeaders(response);
-        response.getWriter().write(objectMapper.writeValueAsString(body));
-    }
-
-    private ApiErrorResponse createErrorResponseBody(HttpServletRequest request) {
-        return ApiErrorResponse.of(
-            AuthErrorCode.ACCESS_TOKEN_INVALID.name(),
-            AuthErrorCode.ACCESS_TOKEN_INVALID.defaultMessage(),
-            HttpStatus.UNAUTHORIZED.value(),
+        ApiErrorResponse body = ApiErrorResponse.of(
+            CommonErrorCode.FORBIDDEN.name(),
+            CommonErrorCode.FORBIDDEN.defaultMessage(),
+            HttpStatus.FORBIDDEN.value(),
             request.getRequestURI()
         );
-    }
-
-    private void setResponseHeaders(HttpServletResponse response) {
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 
     private String resolveUserInfoSafely(HttpServletRequest request) {

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/handler/JwtAuthenticationEntryPoint.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.handler;
 
+import com.eventitta.domain.auth.exception.AuthErrorCode;
 import com.eventitta.api.auth.jwt.UserInfoService;
-import com.eventitta.domain.common.exception.CommonErrorCode;
 import com.eventitta.api.common.response.ApiErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -19,40 +19,44 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
     private final UserInfoService userInfoService;
 
     @Override
-    public void handle(
-        HttpServletRequest request,
-        HttpServletResponse response,
-        AccessDeniedException accessDeniedException
-    ) throws IOException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         log.warn(
-            "[Exception] Access denied errorCode={}, status={}, path={}, userInfo={}, exceptionType={}, message={}",
-            CommonErrorCode.FORBIDDEN.name(),
-            HttpStatus.FORBIDDEN.value(),
+            "[Exception] Authentication failure errorCode={}, status={}, path={}, userInfo={}, exceptionType={}, message={}",
+            AuthErrorCode.ACCESS_TOKEN_INVALID.name(),
+            HttpStatus.UNAUTHORIZED.value(),
             request.getRequestURI(),
             resolveUserInfoSafely(request),
-            accessDeniedException.getClass().getName(),
-            accessDeniedException.getMessage()
+            authException.getClass().getName(),
+            authException.getMessage()
         );
         writeErrorResponse(request, response);
     }
 
     private void writeErrorResponse(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        ApiErrorResponse body = ApiErrorResponse.of(
-            CommonErrorCode.FORBIDDEN.name(),
-            CommonErrorCode.FORBIDDEN.defaultMessage(),
-            HttpStatus.FORBIDDEN.value(),
+        ApiErrorResponse body = createErrorResponseBody(request);
+        setResponseHeaders(response);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+
+    private ApiErrorResponse createErrorResponseBody(HttpServletRequest request) {
+        return ApiErrorResponse.of(
+            AuthErrorCode.ACCESS_TOKEN_INVALID.name(),
+            AuthErrorCode.ACCESS_TOKEN_INVALID.defaultMessage(),
+            HttpStatus.UNAUTHORIZED.value(),
             request.getRequestURI()
         );
-        response.setStatus(HttpStatus.FORBIDDEN.value());
+    }
+
+    private void setResponseHeaders(HttpServletResponse response) {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(body));
     }
 
     private String resolveUserInfoSafely(HttpServletRequest request) {

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/principal/UserPrincipal.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/principal/UserPrincipal.java
@@ -1,4 +1,4 @@
-package com.eventitta.api.auth.security;
+package com.eventitta.api.auth.security.principal;
 
 import com.eventitta.domain.user.api.internal.view.UserAuthView;
 import lombok.Getter;

--- a/eventitta-api/src/main/java/com/eventitta/api/auth/security/userdetails/CustomUserDetailsService.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/auth/security/userdetails/CustomUserDetailsService.java
@@ -1,6 +1,6 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.userdetails;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.domain.user.api.internal.facade.UserInternalFacade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/eventitta-api/src/main/java/com/eventitta/api/gamification/controller/RankingController.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/gamification/controller/RankingController.java
@@ -1,6 +1,6 @@
 package com.eventitta.api.gamification.controller;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.domain.gamification.domain.RankingType;
 import com.eventitta.domain.gamification.dto.response.RankingPageResponse;
 import com.eventitta.domain.gamification.dto.response.UserRankResponse;

--- a/eventitta-api/src/main/java/com/eventitta/api/post/controller/PostController.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/post/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.eventitta.api.post.controller;
 
 import com.eventitta.api.auth.security.annotation.CurrentUser;
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.domain.common.response.PageResponse;
 import com.eventitta.domain.post.dto.PostFilter;
 import com.eventitta.domain.post.dto.request.CreatePostRequest;

--- a/eventitta-api/src/main/java/com/eventitta/api/user/controller/UserController.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/user/controller/UserController.java
@@ -2,7 +2,7 @@ package com.eventitta.api.user.controller;
 
 import com.eventitta.api.auth.security.annotation.CurrentUser;
 import com.eventitta.api.common.response.ApiErrorResponse;
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.api.auth.controller.request.SocialLoginRequest;
 import com.eventitta.api.auth.AuthConstants;
 import com.eventitta.api.auth.controller.AuthMapper;

--- a/eventitta-api/src/test/java/com/eventitta/api/auth/controller/AuthControllerTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/auth/controller/AuthControllerTest.java
@@ -1,6 +1,6 @@
 package com.eventitta.api.auth.controller;
 
-import com.eventitta.api.auth.SecurityConfig;
+import com.eventitta.api.auth.security.config.SecurityConfig;
 import com.eventitta.api.auth.AuthConstants;
 import com.eventitta.api.auth.controller.request.ActionTokenRequest;
 import com.eventitta.api.auth.controller.request.EmailRequest;
@@ -9,13 +9,13 @@ import com.eventitta.api.auth.controller.request.SignInRequest;
 import com.eventitta.api.auth.controller.request.SignUpRequest;
 import com.eventitta.api.auth.controller.request.SocialAuthorizeRequest;
 import com.eventitta.api.auth.controller.request.SocialLoginRequest;
-import com.eventitta.api.auth.jwt.JwtAccessDeniedHandler;
-import com.eventitta.api.auth.jwt.JwtAuthenticationEntryPoint;
+import com.eventitta.api.auth.security.handler.JwtAccessDeniedHandler;
+import com.eventitta.api.auth.security.handler.JwtAuthenticationEntryPoint;
 import com.eventitta.api.auth.jwt.JwtTokenProvider;
-import com.eventitta.api.auth.jwt.CustomUserDetailsService;
+import com.eventitta.api.auth.security.userdetails.CustomUserDetailsService;
 import com.eventitta.api.auth.jwt.UserInfoService;
 import com.eventitta.api.auth.controller.AuthMapperImpl;
-import com.eventitta.api.auth.security.SecurityCorsProperties;
+import com.eventitta.api.auth.security.config.SecurityCorsProperties;
 import com.eventitta.api.auth.session.ClientSessionMetadataResolver;
 import com.eventitta.api.auth.cookie.CookieManager;
 import com.eventitta.api.auth.oauth.kakao.KakaoAuthorizationSupport;

--- a/eventitta-api/src/test/java/com/eventitta/api/auth/security/credential/AuthenticationManagerCredentialAuthenticatorTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/auth/security/credential/AuthenticationManagerCredentialAuthenticatorTest.java
@@ -1,6 +1,6 @@
-package com.eventitta.api.auth.security;
+package com.eventitta.api.auth.security.credential;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/eventitta-api/src/test/java/com/eventitta/api/auth/security/filter/JwtAuthenticationFilterTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/auth/security/filter/JwtAuthenticationFilterTest.java
@@ -1,6 +1,6 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.filter;
 
-import com.eventitta.api.auth.security.UserPrincipal;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
 import com.eventitta.api.auth.jwt.JwtTokenProvider;
 import com.eventitta.api.auth.jwt.ParsedAccessToken;
 import com.eventitta.domain.auth.domain.RefreshToken;

--- a/eventitta-api/src/test/java/com/eventitta/api/auth/security/handler/JwtAccessDeniedHandlerTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/auth/security/handler/JwtAccessDeniedHandlerTest.java
@@ -1,4 +1,4 @@
-package com.eventitta.api.auth.jwt;
+package com.eventitta.api.auth.security.handler;
 
 import com.eventitta.api.auth.jwt.UserInfoService;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/eventitta-api/src/test/java/com/eventitta/api/auth/security/principal/UserPrincipalTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/auth/security/principal/UserPrincipalTest.java
@@ -1,4 +1,4 @@
-package com.eventitta.api.auth.security;
+package com.eventitta.api.auth.security.principal;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/eventitta-api/src/test/java/com/eventitta/api/user/controller/UserControllerSocialLinkTest.java
+++ b/eventitta-api/src/test/java/com/eventitta/api/user/controller/UserControllerSocialLinkTest.java
@@ -1,16 +1,16 @@
 package com.eventitta.api.user.controller;
 
-import com.eventitta.api.auth.SecurityConfig;
+import com.eventitta.api.auth.security.config.SecurityConfig;
 import com.eventitta.api.auth.AuthConstants;
 import com.eventitta.api.auth.controller.request.SocialLoginRequest;
-import com.eventitta.api.auth.security.UserPrincipal;
-import com.eventitta.api.auth.jwt.JwtAccessDeniedHandler;
-import com.eventitta.api.auth.jwt.JwtAuthenticationEntryPoint;
+import com.eventitta.api.auth.security.principal.UserPrincipal;
+import com.eventitta.api.auth.security.handler.JwtAccessDeniedHandler;
+import com.eventitta.api.auth.security.handler.JwtAuthenticationEntryPoint;
 import com.eventitta.api.auth.jwt.JwtTokenProvider;
-import com.eventitta.api.auth.jwt.CustomUserDetailsService;
+import com.eventitta.api.auth.security.userdetails.CustomUserDetailsService;
 import com.eventitta.api.auth.jwt.UserInfoService;
 import com.eventitta.api.auth.controller.AuthMapperImpl;
-import com.eventitta.api.auth.security.SecurityCorsProperties;
+import com.eventitta.api.auth.security.config.SecurityCorsProperties;
 import com.eventitta.api.auth.cookie.CookieManager;
 import com.eventitta.api.auth.oauth.kakao.KakaoAuthorizationSupport;
 import com.eventitta.api.user.mapper.UserMapper;


### PR DESCRIPTION
## Summary

Groups api/auth security-related classes by Spring Security role into 2-depth subpackages, so the role of each class is obvious from its path instead of its filename. Also frees `jwt/` to hold only pure JWT tech (no Spring Security types).

## New security/ layout

```
api/auth/
├ AuthConstants.java
├ security/
│  ├ config/       SecurityConfig, SecurityCorsProperties
│  ├ principal/    UserPrincipal
│  ├ annotation/   CurrentUser               (from #157)
│  ├ filter/       JwtAuthenticationFilter
│  ├ userdetails/  CustomUserDetailsService
│  ├ handler/      JwtAccessDeniedHandler, JwtAuthenticationEntryPoint
│  └ credential/   AuthenticationManagerCredentialAuthenticator
├ jwt/             JwtProperties, JwtTokenUtil, JwtTokenProvider, ParsedAccessToken, UserInfoService*
└ controller/ · cookie/ · oauth/kakao/ · session/
```

\* `UserInfoService` stays in `jwt/` intentionally — see \"Scope notes\".

## Why SecurityConfig moved into security/config/

In PR #156 `SecurityConfig` was hoisted to the slice root to break a `security → jwt → security` cycle. With `JwtAuthenticationFilter` now inside `security/filter/`, that cycle is gone: the dependency graph is
```
security/{config,filter,userdetails,handler,credential} → jwt → security/principal
```
no back-edges into `security/config/`. So the root can return to being a clean slice landing pad (only `AuthConstants` remains there).

## Scope notes

- **No behavior change.** Moves only (plus package declarations + FQN imports).
- **UserInfoService stays in jwt/ on purpose.** Its two public methods solve two unrelated problems — normal-flow actor lookup (used by `GlobalExceptionHandler`, ~5 lines) vs. auth-failure actor forensics including tampered-token parsing (used by the two handlers, ~100 lines). They will be split into \`HandlerActorResolver\` (under \`security/handler/\`) and \`CurrentRequestActorResolver\` (under \`api/common/logging/\`) in a follow-up PR. Moving it here would be throwaway work.

## Test plan

- [x] \`./gradlew testClasses\` passes
- [x] \`./gradlew :eventitta-app:test\` (ArchUnit) passes
- [x] \`./gradlew :eventitta-api:test\` passes
- [x] Zero stale references to old FQNs across all four modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)