### PR TITLE
chore: ignore generated sources across all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ local.properties
 *_LOCAL_*.txt
 *_REMOTE_*.txt
 
-/src/main/generated
+**/src/main/generated/
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider


### PR DESCRIPTION
## Summary

- `.gitignore` L82의 `/src/main/generated` 패턴을 `**/src/main/generated/`로 교체.
- 기존 패턴은 **루트 기준 절대 경로**라 단일 모듈 프로젝트에만 매치됨. 모노리포 분리 이후 실제 산출물 경로인 `eventitta-api/src/main/generated`, `eventitta-domain/src/main/generated`가 매치되지 않아 MapStruct/QueryDSL 산출물이 매번 untracked로 잡혔음 (최근 PR들에서 \`Warning: N uncommitted changes\`의 원인).

## Verification

\`\`\`
$ git check-ignore -v eventitta-api/src/main/generated/ eventitta-domain/src/main/generated/
.gitignore:82:**/src/main/generated/	eventitta-api/src/main/generated/
.gitignore:82:**/src/main/generated/	eventitta-domain/src/main/generated/
\`\`\`

## Test plan

- [x] `git check-ignore` 로 두 경로가 새 패턴에 매치됨을 확인
- [x] `git status` 에서 generated 디렉터리가 사라짐을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)