### PR TITLE
refactor: remove UserMapper entity leak and guard with ArchUnit

### DIFF
--- a/eventitta-api/src/main/java/com/eventitta/api/user/mapper/UserMapper.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/user/mapper/UserMapper.java
@@ -3,7 +3,6 @@ package com.eventitta.api.user.mapper;
 import com.eventitta.api.user.controller.request.ChangePasswordRequest;
 import com.eventitta.api.user.controller.request.UpdateProfileRequest;
 import com.eventitta.api.user.controller.response.UserProfileResponse;
-import com.eventitta.domain.user.domain.User;
 import com.eventitta.domain.user.service.dto.ChangePasswordCommand;
 import com.eventitta.domain.user.service.dto.UpdateProfileCommand;
 import com.eventitta.domain.user.service.dto.UserProfileResult;
@@ -15,8 +14,6 @@ public interface UserMapper {
     UpdateProfileCommand toUpdateProfileCommand(UpdateProfileRequest request);
 
     ChangePasswordCommand toChangePasswordCommand(ChangePasswordRequest request);
-
-    UserProfileResult toUserProfileResult(User user);
 
     UserProfileResponse toUserProfileResponse(UserProfileResult result);
 }

--- a/eventitta-app/src/test/java/com/eventitta/architecture/ModularStructureArchTest.java
+++ b/eventitta-app/src/test/java/com/eventitta/architecture/ModularStructureArchTest.java
@@ -70,6 +70,15 @@ class ModularStructureArchTest {
             .resideInAnyPackage("com.eventitta.infra..");
 
     @ArchTest
+    static final ArchRule apiMustNotDependOnDomainEntities =
+        noClasses()
+            .that()
+            .resideInAnyPackage("com.eventitta.api..")
+            .should()
+            .dependOnClassesThat()
+            .areAnnotatedWith(Entity.class);
+
+    @ArchTest
     static final ArchRule apiAuthMustNotContainBusinessServices =
         noClasses()
             .should()


### PR DESCRIPTION
## Summary

- \`UserMapper.toUserProfileResult(User user)\` 제거 — api 레이어가 domain \`@Entity User\`를 직접 매개변수로 받는 **유일한 경계 위반** 지점이었고, 실제로 **호출자가 없는 dead signature**였음. \`UserService.getProfile()\`이 이미 리포지토리에서 엔티티를 꺼낸 직후 \`UserProfileResult\`를 직접 생성해 반환하므로 API 쪽 매퍼는 불필요.
- 회귀 방지용 ArchUnit 규칙 \`apiMustNotDependOnDomainEntities\` 추가 — api 모듈이 \`@Entity\` 어노테이션이 붙은 클래스에 의존하지 못하게 강제.

## Why

dead signature일 뿐이어도 존재 자체가 \"api 레이어에서 entity를 받아도 된다\"는 암묵적 허용을 주고, 나중에 누군가가 비슷한 메서드를 추가할 때 정당화 근거가 됨. 제거하는 김에 ArchUnit 가드를 걸어 규칙을 **강제 가능한 불변으로 고정**.

### 남은 api → domain.*.domain.* 의존은 모두 enum

| File | Import | Type |
|---|---|---|
| \`GlobalExceptionHandler\` | \`domain.notification.domain.AlertLevel\` | enum |
| \`FileUploadController\` | \`domain.media.domain.MediaCategory\` | enum |
| \`RankingController\` | \`domain.gamification.domain.RankingType\` | enum |

enum은 \`@Entity\`가 아니므로 새 규칙에 걸리지 않음. 값 객체로서 레이어 간 공유는 정당.

## Test plan

- [x] \`./gradlew :eventitta-app:test :eventitta-api:test\` (ArchUnit + WebMvc 전체 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)