### PR TITLE
refactor: rename common.monitoring to common.logging

### DIFF
--- a/eventitta-api/src/main/java/com/eventitta/api/common/logging/LogTestController.java
+++ b/eventitta-api/src/main/java/com/eventitta/api/common/logging/LogTestController.java
@@ -1,7 +1,7 @@
-package com.eventitta.api.common.monitoring;
+package com.eventitta.api.common.logging;
 
-import com.eventitta.domain.common.monitoring.LogSanitizer;
-import com.eventitta.domain.common.monitoring.LogStatusProvider;
+import com.eventitta.domain.common.logging.LogSanitizer;
+import com.eventitta.domain.common.logging.LogStatusProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.HashMap;

--- a/eventitta-domain/src/main/java/com/eventitta/domain/common/logging/LogSanitizer.java
+++ b/eventitta-domain/src/main/java/com/eventitta/domain/common/logging/LogSanitizer.java
@@ -1,4 +1,4 @@
-package com.eventitta.domain.common.monitoring;
+package com.eventitta.domain.common.logging;
 
 import java.util.regex.Pattern;
 

--- a/eventitta-domain/src/main/java/com/eventitta/domain/common/logging/LogStatusProvider.java
+++ b/eventitta-domain/src/main/java/com/eventitta/domain/common/logging/LogStatusProvider.java
@@ -1,4 +1,4 @@
-package com.eventitta.domain.common.monitoring;
+package com.eventitta.domain.common.logging;
 
 public interface LogStatusProvider {
 


### PR DESCRIPTION
## Summary

\`api/common/monitoring\`과 \`domain/common/monitoring\`은 같은 이름이지만 **실제 중복이 아니었음**. 두 패키지 모두 로그 관련 클래스만 담고 있고 진짜 모니터링(metrics, tracing, health check)이 아니라 misleading한 이름이었음. 게다가 PR #159에서 이미 \`api/common/logging/\` (RequestActorResolver)을 만들어 둔 상태라 자연스러운 통합 대상이 존재.

### 이동

| Before | After |
|---|---|
| \`domain/common/monitoring/LogSanitizer\` | \`domain/common/logging/LogSanitizer\` |
| \`domain/common/monitoring/LogStatusProvider\` | \`domain/common/logging/LogStatusProvider\` |
| \`api/common/monitoring/LogTestController\` | \`api/common/logging/LogTestController\` |

## Why

- **이름 정정**: \"monitoring\"은 관례상 metrics/tracing/health을 의미하는데 내용물은 \`LogSanitizer\`(PII 마스킹), \`LogStatusProvider\`(로그 상태), \`LogTestController\`(dev 로그 테스트 엔드포인트)로 모두 로깅 유틸. 이름이 내용과 어긋나면 \"모니터링 기능 추가 PR\"을 찾는 사람이 헷갈림.
- **기존 \`logging/\` 패키지와의 일관성**: \`api/common/logging/RequestActorResolver\`가 이미 로깅용 actor 해석 책임을 맡고 있음. 같은 카테고리의 \`LogTestController\`가 \`monitoring/\`에 있을 이유 없음.
- **\`docs/ARCHITECTURE.md\`의 known deviations 중 \"api/common/monitoring과 domain/common/monitoring 같은 이름의 공통 패키지 중복\" 항목 해소**.

## Test plan

- [x] \`./gradlew :eventitta-app:test :eventitta-api:test :eventitta-domain:test :eventitta-infra:test\` 전 모듈 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)