### PR TITLE
refactor(notification): Add Discord alert notification support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@ fabric.properties
 
 # Editor-based Rest Client
 .idea/httpRequests
+http/
+http/http-client.private.env.json
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
@@ -365,3 +367,4 @@ HELP.md
 /db/
 /logs
 /uploads
+/eventitta-app/logs

--- a/eventitta-infra/src/main/java/com/eventitta/infra/notification/config/AlertNotificationConfig.java
+++ b/eventitta-infra/src/main/java/com/eventitta/infra/notification/config/AlertNotificationConfig.java
@@ -1,0 +1,44 @@
+package com.eventitta.infra.notification.config;
+
+import com.eventitta.domain.notification.service.AlertNotificationService;
+import com.eventitta.infra.notification.service.DiscordAlertMessageBuilder;
+import com.eventitta.infra.notification.service.DiscordAlertNotificationService;
+import com.eventitta.infra.notification.service.NoopAlertNotificationService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.web.client.RestClient;
+
+import java.time.Clock;
+
+@Configuration
+@EnableConfigurationProperties(DiscordAlertProperties.class)
+public class AlertNotificationConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "notification.discord", name = "enabled", havingValue = "true")
+    public AlertNotificationService discordAlertNotificationService(
+        DiscordAlertProperties properties,
+        DiscordAlertMessageBuilder messageBuilder,
+        Environment environment,
+        Clock clock,
+        RestClient.Builder restClientBuilder
+    ) {
+        return new DiscordAlertNotificationService(
+            properties,
+            messageBuilder,
+            environment,
+            clock,
+            restClientBuilder
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(AlertNotificationService.class)
+    public AlertNotificationService noopAlertNotificationService() {
+        return new NoopAlertNotificationService();
+    }
+}

--- a/eventitta-infra/src/main/java/com/eventitta/infra/notification/config/DiscordAlertProperties.java
+++ b/eventitta-infra/src/main/java/com/eventitta/infra/notification/config/DiscordAlertProperties.java
@@ -1,0 +1,28 @@
+package com.eventitta.infra.notification.config;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "notification.discord")
+@Getter
+@Setter
+public class DiscordAlertProperties {
+
+    private boolean enabled = false;
+    private String webhookUrl;
+    private String username = "eventitta-bot";
+
+    @Min(1)
+    private int timeoutSeconds = 5;
+
+    @AssertTrue(message = "notification.discord.webhook-url must be configured when Discord alerts are enabled")
+    public boolean isWebhookConfiguredWhenEnabled() {
+        return !enabled || StringUtils.hasText(webhookUrl);
+    }
+}

--- a/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/DiscordAlertMessageBuilder.java
+++ b/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/DiscordAlertMessageBuilder.java
@@ -1,0 +1,105 @@
+package com.eventitta.infra.notification.service;
+
+import com.eventitta.domain.notification.constants.AlertConstants;
+import com.eventitta.domain.notification.domain.AlertLevel;
+import com.eventitta.domain.notification.domain.DiscordEmbed;
+import com.eventitta.domain.notification.domain.DiscordField;
+import com.eventitta.domain.notification.domain.DiscordFooter;
+import com.eventitta.domain.notification.domain.DiscordMessage;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DiscordAlertMessageBuilder {
+
+    private static final int MAX_STACK_TRACE_LINES = 3;
+    private static final String ALERT_TITLE_FORMAT = "%s - %s [%s]";
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final Clock clock;
+
+    public DiscordAlertMessageBuilder(Clock clock) {
+        this.clock = clock;
+    }
+
+    public DiscordMessage build(
+        AlertLevel level,
+        String errorCode,
+        String message,
+        String requestUri,
+        String userInfo,
+        Throwable exception,
+        String environment,
+        String username
+    ) {
+        DiscordEmbed embed = DiscordEmbed.builder()
+            .title(String.format(ALERT_TITLE_FORMAT, errorCode, level, environment))
+            .description(message)
+            .color(level.getDiscordColor())
+            .fields(buildFields(level, requestUri, userInfo, exception))
+            .footer(DiscordFooter.builder()
+                .text(LocalDateTime.now(clock).format(TIMESTAMP_FORMAT))
+                .build())
+            .build();
+
+        return DiscordMessage.builder()
+            .content(String.format(AlertConstants.ALERT_TEXT_FORMAT, level.name(), "notification"))
+            .username(username)
+            .embeds(List.of(embed))
+            .build();
+    }
+
+    private List<DiscordField> buildFields(
+        AlertLevel level,
+        String requestUri,
+        String userInfo,
+        Throwable exception
+    ) {
+        List<DiscordField> fields = new ArrayList<>();
+
+        if (StringUtils.hasText(requestUri)) {
+            fields.add(DiscordField.builder()
+                .name("Request URI")
+                .value(requestUri)
+                .inline(true)
+                .build());
+        }
+
+        if (StringUtils.hasText(userInfo)) {
+            fields.add(DiscordField.builder()
+                .name("User")
+                .value(userInfo)
+                .inline(true)
+                .build());
+        }
+
+        if (exception != null && level == AlertLevel.CRITICAL) {
+            fields.add(DiscordField.builder()
+                .name("Exception")
+                .value("```" + shortenStackTrace(exception) + "```")
+                .inline(false)
+                .build());
+        }
+
+        return fields;
+    }
+
+    private String shortenStackTrace(Throwable exception) {
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        return Arrays.stream(stringWriter.toString().split(LINE_SEPARATOR))
+            .limit(MAX_STACK_TRACE_LINES)
+            .collect(Collectors.joining(LINE_SEPARATOR));
+    }
+}

--- a/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/DiscordAlertNotificationService.java
+++ b/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/DiscordAlertNotificationService.java
@@ -1,0 +1,122 @@
+package com.eventitta.infra.notification.service;
+
+import com.eventitta.domain.notification.constants.AlertConstants;
+import com.eventitta.domain.notification.domain.AlertLevel;
+import com.eventitta.domain.notification.domain.DiscordMessage;
+import com.eventitta.domain.notification.service.AlertNotificationService;
+import com.eventitta.infra.notification.config.DiscordAlertProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.web.client.RestClient;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class DiscordAlertNotificationService implements AlertNotificationService {
+
+    private static final Duration RATE_LIMIT_WINDOW = Duration.ofMinutes(AlertConstants.RATE_LIMIT_WINDOW_MINUTES);
+
+    private final DiscordAlertProperties properties;
+    private final DiscordAlertMessageBuilder messageBuilder;
+    private final Environment environment;
+    private final Clock clock;
+    private final RestClient restClient;
+    private final Map<String, AlertWindow> alertWindows = new ConcurrentHashMap<>();
+
+    public DiscordAlertNotificationService(
+        DiscordAlertProperties properties,
+        DiscordAlertMessageBuilder messageBuilder,
+        Environment environment,
+        Clock clock,
+        RestClient.Builder restClientBuilder
+    ) {
+        this.properties = properties;
+        this.messageBuilder = messageBuilder;
+        this.environment = environment;
+        this.clock = clock;
+        this.restClient = restClientBuilder
+            .requestFactory(createRequestFactory(properties))
+            .build();
+    }
+
+    @Async
+    @Override
+    public void sendAlert(
+        AlertLevel level,
+        String errorCode,
+        String message,
+        String requestUri,
+        String userInfo,
+        Throwable exception
+    ) {
+        if (!shouldSend(errorCode, level)) {
+            return;
+        }
+
+        try {
+            DiscordMessage discordMessage = messageBuilder.build(
+                level,
+                errorCode,
+                message,
+                requestUri,
+                userInfo,
+                exception,
+                activeProfile(),
+                properties.getUsername()
+            );
+
+            restClient.post()
+                .uri(properties.getWebhookUrl())
+                .body(discordMessage)
+                .retrieve()
+                .toBodilessEntity();
+
+            log.info("Discord alert sent. level={}, errorCode={}", level, errorCode);
+        } catch (Exception sendException) {
+            log.error("Discord alert send failed. errorCode={}, type={}", errorCode,
+                sendException.getClass().getSimpleName(), sendException);
+        }
+    }
+
+    private boolean shouldSend(String errorCode, AlertLevel level) {
+        Instant now = clock.instant();
+        cleanupExpired(now);
+
+        String key = errorCode + ":" + level;
+        AlertWindow window = alertWindows.compute(key, (ignored, current) -> {
+            if (current == null || current.startedAt().plus(RATE_LIMIT_WINDOW).isBefore(now)) {
+                return new AlertWindow(now, 1);
+            }
+            return new AlertWindow(current.startedAt(), current.count() + 1);
+        });
+
+        return window.count() <= level.getAlertLimit();
+    }
+
+    private void cleanupExpired(Instant now) {
+        alertWindows.entrySet().removeIf(entry ->
+            entry.getValue().startedAt().plus(RATE_LIMIT_WINDOW).isBefore(now));
+    }
+
+    private String activeProfile() {
+        String[] activeProfiles = environment.getActiveProfiles();
+        return activeProfiles.length == 0 ? "default" : activeProfiles[0];
+    }
+
+    private SimpleClientHttpRequestFactory createRequestFactory(DiscordAlertProperties properties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        int timeoutMillis = Math.toIntExact(Duration.ofSeconds(properties.getTimeoutSeconds()).toMillis());
+        requestFactory.setConnectTimeout(timeoutMillis);
+        requestFactory.setReadTimeout(timeoutMillis);
+        return requestFactory;
+    }
+
+    private record AlertWindow(Instant startedAt, int count) {
+    }
+}

--- a/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/NoopAlertNotificationService.java
+++ b/eventitta-infra/src/main/java/com/eventitta/infra/notification/service/NoopAlertNotificationService.java
@@ -1,0 +1,18 @@
+package com.eventitta.infra.notification.service;
+
+import com.eventitta.domain.notification.domain.AlertLevel;
+import com.eventitta.domain.notification.service.AlertNotificationService;
+
+public class NoopAlertNotificationService implements AlertNotificationService {
+
+    @Override
+    public void sendAlert(
+        AlertLevel level,
+        String errorCode,
+        String message,
+        String requestUri,
+        String userInfo,
+        Throwable exception
+    ) {
+    }
+}


### PR DESCRIPTION
This pull request adds a new infrastructure for sending alert notifications via Discord webhooks, with configurable properties, message formatting, and rate limiting. It introduces Spring configuration for enabling/disabling Discord alerts, implements the Discord alert notification service with rate limiting, and provides a no-op fallback service when Discord alerts are disabled.

**Discord Alert Notification Integration:**

* Added `AlertNotificationConfig` for Spring-based configuration, enabling Discord alerts via properties and providing a fallback no-op service if disabled.
* Introduced `DiscordAlertProperties` to allow configuration of Discord webhook URL, username, enable flag, and timeout, with validation to ensure correct setup.

**Discord Alert Notification Service Implementation:**

* Implemented `DiscordAlertNotificationService` to send alerts to Discord using the configured webhook, including rate limiting per error code and alert level, and asynchronous sending.
* Added `DiscordAlertMessageBuilder` to format Discord messages, including error details, user info, and (for critical alerts) a shortened stack trace.

**Fallback Service:**

* Added `NoopAlertNotificationService` as a no-operation implementation for environments where Discord alerts are not enabled.